### PR TITLE
Structure of transformation code from team demo

### DIFF
--- a/src/main/java/gov/cdc/izgateway/transformation/ApplicationController.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/ApplicationController.java
@@ -1,15 +1,58 @@
 package gov.cdc.izgateway.transformation;
 
+import ca.uhn.hl7v2.model.Message;
+import gov.cdc.izgateway.transformation.chains.PipelineChain;
+import gov.cdc.izgateway.transformation.chains.PipelineChainBuilder;
+import gov.cdc.izgateway.transformation.configuration.ServiceConfig;
+import gov.cdc.izgateway.transformation.context.ServiceContext;
+import gov.cdc.izgateway.transformation.mllp.MllpSender;
 import lombok.extern.java.Log;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.logging.Level;
 
 @Log
 @RestController
 public class ApplicationController {
 
-  @GetMapping("/hello")
-  public String transform() {
-    return "Hello from ApplicationController!";
-  }
+    @Autowired
+    ServiceConfig serviceConfig;
+
+    @Autowired
+    PipelineChainBuilder pipelineBuilder;
+
+    @GetMapping("/hello")
+    public String transform() {
+        return "Hello from ApplicationController!";
+    }
+
+    @PutMapping("/transform")
+    public String transform(@RequestBody String incomingMessage, @RequestHeader HttpHeaders headers) {
+        try {
+
+            // TODO - need to figure out how to determine Org, IB & OB
+            // TODO - this is all just for DEMO
+            String organization = headers.getFirst("X-izgw-organization");
+            String inboundEndpoint = headers.getFirst("X-izgw-ib");
+            String outboundEndpoint = headers.getFirst("X-izgw-ob");
+
+            ServiceContext context = new ServiceContext(organization, inboundEndpoint, outboundEndpoint, incomingMessage);
+
+            PipelineChain pipeline = pipelineBuilder.build(context);
+            pipeline.execute(context.getRequestMessage(), "request");
+
+            // At this point request message has been transformed, we need to send it and deal with the response
+            Message responseMessage = MllpSender.send("localhost", 6661, context.getRequestMessage());
+
+            pipeline.execute(responseMessage, "response");
+
+            assert responseMessage != null;
+            return responseMessage.encode();
+        } catch (Exception e) {
+            log.log(Level.SEVERE, e.getMessage());
+            return e.getMessage();
+        }
+    }
 }

--- a/src/main/java/gov/cdc/izgateway/transformation/chains/Hl7v2OperationChain.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/chains/Hl7v2OperationChain.java
@@ -1,0 +1,27 @@
+package gov.cdc.izgateway.transformation.chains;
+
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.Message;
+import gov.cdc.izgateway.transformation.operations.Operation;
+
+public class Hl7v2OperationChain {
+    private Operation firstOperation;
+
+    public void addOperation(Operation operation) {
+        if (firstOperation == null) {
+            firstOperation = operation;
+        } else {
+            Operation currentOperation = firstOperation;
+            while (currentOperation.getNextOperation() != null) {
+                currentOperation = currentOperation.getNextOperation();
+            }
+            currentOperation.setNextOperation(operation);
+        }
+    }
+
+    public void execute(Message message) throws HL7Exception {
+        if (firstOperation != null) {
+            firstOperation.transform(message);
+        }
+    }
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/chains/PipelineChain.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/chains/PipelineChain.java
@@ -1,0 +1,31 @@
+package gov.cdc.izgateway.transformation.chains;
+
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.Message;
+import gov.cdc.izgateway.transformation.pipelines.Pipeline;
+import lombok.extern.java.Log;
+
+@Log
+public class PipelineChain {
+
+    private Pipeline firstPipeline;
+
+    public void addPipeline(Pipeline pipeline) {
+        if (firstPipeline == null) {
+            firstPipeline = pipeline;
+        } else {
+            Pipeline currentPipeline = firstPipeline;
+            while (currentPipeline.getNextPipeline() != null) {
+                currentPipeline = currentPipeline.getNextPipeline();
+            }
+            currentPipeline.setNextPipeline(pipeline);
+        }
+    }
+
+    public void execute(Message message, String direction) throws HL7Exception {
+        if (firstPipeline != null) {
+            firstPipeline.execute(message, direction);
+        }
+    }
+
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/chains/PipelineChainBuilder.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/chains/PipelineChainBuilder.java
@@ -1,0 +1,52 @@
+package gov.cdc.izgateway.transformation.chains;
+
+import gov.cdc.izgateway.transformation.configuration.OrganizationConfig;
+import gov.cdc.izgateway.transformation.configuration.PipelineConfig;
+import gov.cdc.izgateway.transformation.configuration.ServiceConfig;
+import gov.cdc.izgateway.transformation.context.ServiceContext;
+import gov.cdc.izgateway.transformation.pipelines.Hl7Pipeline;
+import lombok.extern.java.Log;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Log
+public class PipelineChainBuilder {
+    @Autowired
+    ServiceConfig serviceConfig;
+
+    public PipelineChain build(ServiceContext context) {
+        PipelineChain chain = new PipelineChain();
+
+        // TODO - clean this up, quick/dirty obviously can be better
+
+        // get Organization objects for the context org
+        List<OrganizationConfig> organizations = serviceConfig
+                .getOrganizations()
+                .stream()
+                .filter(
+                        org -> org.getOrganizationName().equals(context.getOrganizationName())
+                )
+                .toList();
+
+        // get pipelines for the context ib and ob endpoints
+        List<PipelineConfig> pipelineConfigs = new ArrayList<>();
+        for (OrganizationConfig organizationConfig : organizations) {
+            pipelineConfigs = organizationConfig.getPipelines().stream()
+                    .filter(
+                            pipeline -> pipeline.getInboundEndpoint().equals(context.getInboundEndpoint()) && pipeline.getOutboundEndpoint().equals(context.getOutboundEndpoint())
+                    )
+                    .toList();
+        }
+
+        // build chain
+        for (PipelineConfig pipelineConfig : pipelineConfigs) {
+            chain.addPipeline(new Hl7Pipeline(pipelineConfig));
+        }
+
+        return chain;
+    }
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/configuration/DataTransformationConfig.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/configuration/DataTransformationConfig.java
@@ -1,0 +1,15 @@
+package gov.cdc.izgateway.transformation.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@Getter
+@Setter
+public class DataTransformationConfig {
+    private OperationConfig precondition;
+    private List<OperationConfig> operationList;
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/configuration/OperationConfig.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/configuration/OperationConfig.java
@@ -1,0 +1,20 @@
+package gov.cdc.izgateway.transformation.configuration;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@Setter
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "method")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = OperationCopyConfig.class, name = "copy"),
+        @JsonSubTypes.Type(value = OperationSetConfig.class, name = "set"),
+        @JsonSubTypes.Type(value = OperationEqualsConfig.class, name = "equals")
+})
+public class OperationConfig {
+    private int order;
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/configuration/OperationCopyConfig.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/configuration/OperationCopyConfig.java
@@ -1,0 +1,13 @@
+package gov.cdc.izgateway.transformation.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@Setter
+public class OperationCopyConfig extends OperationConfig {
+    private String sourceField;
+    private String destinationField;
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/configuration/OperationEqualsConfig.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/configuration/OperationEqualsConfig.java
@@ -1,0 +1,13 @@
+package gov.cdc.izgateway.transformation.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@Setter
+public class OperationEqualsConfig extends OperationConfig {
+    private String fieldName;
+    private String fieldValue;
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/configuration/OperationSetConfig.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/configuration/OperationSetConfig.java
@@ -1,0 +1,13 @@
+package gov.cdc.izgateway.transformation.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@Setter
+public class OperationSetConfig extends OperationConfig {
+    private String destinationField;
+    private String setValue;
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/configuration/OrganizationConfig.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/configuration/OrganizationConfig.java
@@ -1,0 +1,15 @@
+package gov.cdc.izgateway.transformation.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@Getter
+@Setter
+public class OrganizationConfig {
+    private String organizationName;
+    private List<PipelineConfig> pipelines;
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/configuration/PipelineConfig.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/configuration/PipelineConfig.java
@@ -1,0 +1,18 @@
+package gov.cdc.izgateway.transformation.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@Getter
+@Setter
+public class PipelineConfig {
+    private String pipelineName;
+    private String inboundEndpoint;
+    private String outboundEndpoint;
+    private List<DataTransformationConfig> requestTransformations;
+    private List<DataTransformationConfig> responseTransformations;
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/configuration/ServiceConfig.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/configuration/ServiceConfig.java
@@ -1,0 +1,14 @@
+package gov.cdc.izgateway.transformation.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@Getter
+@Setter
+public class ServiceConfig {
+    private List<OrganizationConfig> organizations;
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/configuration/ServiceConfigLoader.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/configuration/ServiceConfigLoader.java
@@ -1,0 +1,30 @@
+package gov.cdc.izgateway.transformation.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.java.Log;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.logging.Level;
+
+@Configuration
+@Log
+public class ServiceConfigLoader {
+
+    @Bean
+    public ServiceConfig serviceConfig() throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+
+        ClassLoader classloader = Thread.currentThread().getContextClassLoader();
+        InputStream is = classloader.getResourceAsStream("pipelines_test1.json");
+
+        try {
+            return mapper.readValue(is, ServiceConfig.class);
+        } catch (IOException e) {
+            log.log(Level.SEVERE, "Error parsing JSON content: " + e.getMessage());
+            throw e;
+        }
+    }
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/context/ServiceContext.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/context/ServiceContext.java
@@ -1,0 +1,39 @@
+package gov.cdc.izgateway.transformation.context;
+
+import ca.uhn.hl7v2.DefaultHapiContext;
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.Message;
+import ca.uhn.hl7v2.parser.PipeParser;
+import ca.uhn.hl7v2.validation.impl.NoValidation;
+import lombok.Data;
+
+import java.io.IOException;
+
+@Data
+public class ServiceContext {
+    private String organizationName;
+    private String inboundEndpoint;
+    private String outboundEndpoint;
+    private Message requestMessage;
+    private Message responseMessage;
+
+    public ServiceContext(String organizationName, String inboundEndpoint, String outboundEndpoint, String rawHl7Message) throws HL7Exception {
+        this.organizationName = organizationName;
+        this.inboundEndpoint = inboundEndpoint;
+        this.outboundEndpoint = outboundEndpoint;
+
+        this.requestMessage = parseMessage(rawHl7Message);
+    }
+
+    private Message parseMessage(String rawHl7Message) throws HL7Exception {
+        PipeParser parser;
+        try (DefaultHapiContext context = new DefaultHapiContext()) {
+            context.setValidationContext(new NoValidation());
+            parser = context.getPipeParser();
+        } catch (IOException e) {
+            throw new HL7Exception(e);
+        }
+
+        return parser.parse(rawHl7Message);
+    }
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/mllp/MllpSender.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/mllp/MllpSender.java
@@ -1,0 +1,37 @@
+package gov.cdc.izgateway.transformation.mllp;
+
+import ca.uhn.hl7v2.DefaultHapiContext;
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.HapiContext;
+import ca.uhn.hl7v2.app.Connection;
+import ca.uhn.hl7v2.app.Initiator;
+import ca.uhn.hl7v2.llp.LLPException;
+import ca.uhn.hl7v2.model.Message;
+import ca.uhn.hl7v2.validation.impl.NoValidation;
+import lombok.extern.java.Log;
+
+import java.io.IOException;
+import java.util.logging.Level;
+
+@Log
+public class MllpSender {
+
+    private MllpSender() {}
+
+    public static Message send(String host, int port, Message message) {
+
+        try (HapiContext context = new DefaultHapiContext(new NoValidation())) {
+            Connection connection = context.newClient(host, port, false);
+            Initiator initiator = connection.getInitiator();
+            return initiator.sendAndReceive(message);
+        } catch (HL7Exception e) {
+            log.log(Level.SEVERE, "HL7 Exception: " + e.getMessage());
+        } catch (IOException e) {
+            log.log(Level.SEVERE, "IO Exception: " + e.getMessage());
+        } catch (LLPException e) {
+            log.log(Level.SEVERE, "LLP Exception: " + e.getMessage());
+        }
+        return null;
+    }
+}
+

--- a/src/main/java/gov/cdc/izgateway/transformation/operations/BaseConditionalOperation.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/operations/BaseConditionalOperation.java
@@ -1,0 +1,11 @@
+package gov.cdc.izgateway.transformation.operations;
+
+abstract class BaseConditionalOperation<T> implements ConditionalOperation {
+
+    T operationConfig;
+
+    protected BaseConditionalOperation(T configuration) {
+        this.operationConfig = configuration;
+    }
+
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/operations/BaseOperation.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/operations/BaseOperation.java
@@ -1,0 +1,39 @@
+package gov.cdc.izgateway.transformation.operations;
+
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.Message;
+
+abstract class BaseOperation<T> implements Operation {
+
+    Operation nextOperation;
+    T operationConfig;
+
+    protected BaseOperation(T config) {
+        this.operationConfig = config;
+    }
+
+    @Override
+    public void setNextOperation(Operation nextOperation) {
+        this.nextOperation = nextOperation;
+    }
+
+    @Override
+    public Operation getNextOperation() {
+        return nextOperation;
+    }
+
+    @Override
+    public final void transform(Message message) throws HL7Exception {
+        executeOperation(message);
+        executeNextOperation(message);
+    }
+
+    public abstract void executeOperation(Message message) throws HL7Exception;
+
+    public void executeNextOperation(Message message) throws HL7Exception {
+        if (nextOperation != null) {
+            nextOperation.transform(message);
+        }
+    }
+
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/operations/ConditionalOperation.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/operations/ConditionalOperation.java
@@ -1,0 +1,10 @@
+package gov.cdc.izgateway.transformation.operations;
+
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.Message;
+
+public interface ConditionalOperation {
+    boolean evaluate(Message message) throws HL7Exception;
+
+    // TODO - we may need set/next if > 1 single condition on a pipeline
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/operations/Hl7v2CopyOperation.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/operations/Hl7v2CopyOperation.java
@@ -1,0 +1,30 @@
+package gov.cdc.izgateway.transformation.operations;
+
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.Message;
+import ca.uhn.hl7v2.util.Terser;
+import gov.cdc.izgateway.transformation.configuration.OperationCopyConfig;
+import lombok.extern.java.Log;
+
+import java.util.logging.Level;
+
+@Log
+public class Hl7v2CopyOperation extends BaseOperation<OperationCopyConfig> implements Operation {
+
+    public Hl7v2CopyOperation(OperationCopyConfig config) {
+        super(config);
+    }
+    @Override
+    public void executeOperation(Message message) throws HL7Exception {
+
+        log.log(Level.WARNING, String.format("COPY Operation: %s / Copy %s TO %s",
+                this.getClass().getSimpleName(),
+                this.operationConfig.getSourceField(),
+                this.operationConfig.getDestinationField()));
+
+        Terser terser = new Terser(message);
+
+        String sourceValue = terser.get(operationConfig.getSourceField());
+        terser.set(operationConfig.getDestinationField(), sourceValue);
+    }
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/operations/Hl7v2EqualsOperation.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/operations/Hl7v2EqualsOperation.java
@@ -1,0 +1,32 @@
+package gov.cdc.izgateway.transformation.operations;
+
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.Message;
+import ca.uhn.hl7v2.util.Terser;
+import gov.cdc.izgateway.transformation.configuration.OperationEqualsConfig;
+import lombok.extern.java.Log;
+
+import java.util.logging.Level;
+
+@Log
+public class Hl7v2EqualsOperation extends BaseConditionalOperation<OperationEqualsConfig> implements ConditionalOperation {
+
+    public Hl7v2EqualsOperation(OperationEqualsConfig configuration) {
+        super(configuration);
+    }
+
+    @Override
+    public boolean evaluate(Message message) throws HL7Exception {
+        // TODO - finish implementation
+
+        log.log(Level.WARNING, String.format("Precondition Evaluation: %s / Does %s EQUAL %s",
+                this.getClass().getSimpleName(),
+                this.operationConfig.getFieldName(),
+                this.operationConfig.getFieldValue()));
+
+        Terser terser = new Terser(message);
+        String sourceValue = terser.get(operationConfig.getFieldName());
+
+        return (sourceValue.equals(operationConfig.getFieldValue()));
+    }
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/operations/Hl7v2SetOperation.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/operations/Hl7v2SetOperation.java
@@ -1,0 +1,28 @@
+package gov.cdc.izgateway.transformation.operations;
+
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.Message;
+import ca.uhn.hl7v2.util.Terser;
+import gov.cdc.izgateway.transformation.configuration.OperationSetConfig;
+import lombok.extern.java.Log;
+
+import java.util.logging.Level;
+
+@Log
+public class Hl7v2SetOperation extends BaseOperation<OperationSetConfig> implements Operation {
+
+    public Hl7v2SetOperation(OperationSetConfig config) {
+        super(config);
+    }
+    @Override
+    public void executeOperation(Message message) throws HL7Exception {
+
+        log.log(Level.WARNING, String.format("SET Operation: %s / SET %s TO %s",
+                this.getClass().getSimpleName(),
+                this.operationConfig.getDestinationField(),
+                this.operationConfig.getSetValue()));
+
+        Terser terser = new Terser(message);
+        terser.set(operationConfig.getDestinationField(), operationConfig.getSetValue());
+    }
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/operations/Operation.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/operations/Operation.java
@@ -1,0 +1,14 @@
+package gov.cdc.izgateway.transformation.operations;
+
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.Message;
+
+public interface Operation {
+
+    void transform(Message message) throws HL7Exception;
+
+    void setNextOperation(Operation nextOperation);
+
+    Operation getNextOperation();
+
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/pipelines/BasePipeline.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/pipelines/BasePipeline.java
@@ -1,0 +1,40 @@
+package gov.cdc.izgateway.transformation.pipelines;
+
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.Message;
+import gov.cdc.izgateway.transformation.configuration.PipelineConfig;
+
+abstract class BasePipeline implements Pipeline {
+
+    Pipeline nextPipeline;
+    PipelineConfig configuration;
+
+    protected BasePipeline(PipelineConfig pipelineConfig) {
+        this.configuration = pipelineConfig;
+
+    }
+
+    @Override
+    public void execute(Message message, String direction) throws HL7Exception {
+        executeThisPipeline(message, direction);
+        executeNextPipeline(message, direction);
+    }
+
+    @Override
+    public void setNextPipeline(Pipeline nextPipeline) {
+        this.nextPipeline = nextPipeline;
+    }
+
+    @Override
+    public Pipeline getNextPipeline() {
+        return nextPipeline;
+    }
+
+    public abstract void executeThisPipeline(Message message, String direction) throws HL7Exception;
+
+    public void executeNextPipeline(Message message, String direction) throws HL7Exception {
+        if (nextPipeline != null) {
+            nextPipeline.execute(message, direction);
+        }
+    }
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/pipelines/Hl7Pipeline.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/pipelines/Hl7Pipeline.java
@@ -1,0 +1,59 @@
+package gov.cdc.izgateway.transformation.pipelines;
+
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.Message;
+import gov.cdc.izgateway.transformation.configuration.DataTransformationConfig;
+import gov.cdc.izgateway.transformation.configuration.PipelineConfig;
+import gov.cdc.izgateway.transformation.transformers.Hl7DataTransformation;
+import lombok.extern.java.Log;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+
+@Log
+public class Hl7Pipeline extends BasePipeline implements Pipeline {
+
+    List<Hl7DataTransformation> requestTransformations;
+    List<Hl7DataTransformation> responseTransformation;
+
+
+    public Hl7Pipeline(PipelineConfig pipelineConfig) {
+        super(pipelineConfig);
+
+        // So under single pipeline we will have Request & Response Transformations
+        // Loop those in the pipeline config and build the objects
+        requestTransformations = new ArrayList<>();
+        for (DataTransformationConfig dtConfig : configuration.getRequestTransformations()) {
+            requestTransformations.add(new Hl7DataTransformation(dtConfig));
+        }
+
+        responseTransformation = new ArrayList<>();
+        for (DataTransformationConfig dtConfig : configuration.getResponseTransformations()) {
+            responseTransformation.add(new Hl7DataTransformation(dtConfig));
+        }
+
+    }
+
+    @Override
+    public void executeThisPipeline(Message message, String direction) throws HL7Exception {
+        log.log(Level.WARNING, String.format("Executing %s Pipeline: %s", direction, this.configuration.getPipelineName()));
+        // TODO - finish
+        // TODO - also gross w/ the direction thing definitely needs to be handled differently
+
+        if  (direction.equals("request")) {
+            log.log(Level.WARNING, String.format("Executing Request Transformation with %d operations.",
+                    requestTransformations.size()));
+            for (Hl7DataTransformation dataTransformation : requestTransformations) {
+                dataTransformation.execute(message);
+            }
+        } else if (direction.equals("response")) {
+            log.log(Level.WARNING, String.format("Executing Response Transformation with %d operations.",
+                    responseTransformation.size()));
+
+            for (Hl7DataTransformation dataTransformation : responseTransformation) {
+                dataTransformation.execute(message);
+            }
+        }
+    }
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/pipelines/Pipeline.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/pipelines/Pipeline.java
@@ -1,0 +1,14 @@
+package gov.cdc.izgateway.transformation.pipelines;
+
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.Message;
+
+public interface Pipeline {
+
+    void execute(Message message, String direction) throws HL7Exception;
+
+    void setNextPipeline(Pipeline nextPipeline);
+
+    Pipeline getNextPipeline();
+
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/transformers/BaseDataTransformation.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/transformers/BaseDataTransformation.java
@@ -1,0 +1,11 @@
+package gov.cdc.izgateway.transformation.transformers;
+
+import gov.cdc.izgateway.transformation.configuration.DataTransformationConfig;
+
+abstract class BaseDataTransformation implements DataTransformation {
+    DataTransformationConfig configuration;
+
+    protected BaseDataTransformation(DataTransformationConfig dataTransformationConfig) {
+        this.configuration = dataTransformationConfig;
+    }
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/transformers/DataTransformation.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/transformers/DataTransformation.java
@@ -1,0 +1,8 @@
+package gov.cdc.izgateway.transformation.transformers;
+
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.Message;
+
+public interface DataTransformation {
+    void execute(Message message) throws HL7Exception;
+}

--- a/src/main/java/gov/cdc/izgateway/transformation/transformers/Hl7DataTransformation.java
+++ b/src/main/java/gov/cdc/izgateway/transformation/transformers/Hl7DataTransformation.java
@@ -1,0 +1,59 @@
+package gov.cdc.izgateway.transformation.transformers;
+
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.Message;
+import gov.cdc.izgateway.transformation.chains.Hl7v2OperationChain;
+import gov.cdc.izgateway.transformation.configuration.*;
+import gov.cdc.izgateway.transformation.operations.ConditionalOperation;
+import gov.cdc.izgateway.transformation.operations.Hl7v2CopyOperation;
+import gov.cdc.izgateway.transformation.operations.Hl7v2EqualsOperation;
+import gov.cdc.izgateway.transformation.operations.Hl7v2SetOperation;
+import lombok.extern.java.Log;
+
+import java.util.logging.Level;
+
+@Log
+public class Hl7DataTransformation extends BaseDataTransformation implements DataTransformation {
+    private ConditionalOperation precondition;
+    private final Hl7v2OperationChain operationChain;
+
+    public Hl7DataTransformation(DataTransformationConfig dataTransformationConfig) {
+        super(dataTransformationConfig);
+
+        // Precondition
+        // TODO - this maybe needs to be a list?
+        // TODO - will have to account for other "types" of precondition operations (not equals, etc...)
+        if (configuration.getPrecondition() instanceof OperationEqualsConfig operationEqualsConfig) {
+            precondition = new Hl7v2EqualsOperation(operationEqualsConfig);
+        }
+
+        // Operation(s)
+        // TODO - replace with Chain Builder?
+        operationChain = new Hl7v2OperationChain();
+        for (OperationConfig operationConfig : configuration.getOperationList()) {
+            // I hate this so much there has to be a better way
+            if (operationConfig instanceof OperationCopyConfig operationCopyConfig) {
+                operationChain.addOperation(new Hl7v2CopyOperation(operationCopyConfig));
+            } else if (operationConfig instanceof OperationSetConfig operationSetConfig) {
+                operationChain.addOperation(new Hl7v2SetOperation(operationSetConfig));
+            }
+        }
+
+
+    }
+
+    @Override
+    public void execute(Message message) throws HL7Exception {
+        // TODO - finish implementing this (maybe :) )
+
+
+        // TODO -execute precondition
+        if (precondition.evaluate(message)) {
+            log.log(Level.WARNING, "Precondition Passed");
+            operationChain.execute(message);
+        } else {
+            log.log(Level.WARNING, "Precondition Failed");
+        }
+
+    }
+}

--- a/src/main/resources/pipelines_test1.json
+++ b/src/main/resources/pipelines_test1.json
@@ -1,0 +1,101 @@
+{
+  "organizations": [
+    {
+      "organizationName": "org1",
+      "pipelines": [
+        {
+          "pipelineName": "org1_p1",
+          "inboundEndpoint": "izghubwsdl",
+          "outboundEndpoint": "izghub://dev.phiz-project.org",
+          "requestTransformations": [
+            {
+              "precondition": {
+                "method": "equals",
+                "fieldName": "MSH-3-2",
+                "fieldValue": "AUSTIN",
+                "order": 1
+              },
+              "operationList": [
+                {
+                  "method": "copy",
+                  "sourceField": "MSH-4-1",
+                  "destinationField": "MSH-22-1",
+                  "order": 1
+                },
+                {
+                  "method": "copy",
+                  "sourceField": "MSH-6-1",
+                  "destinationField": "MSH-23-1",
+                  "order": 0
+                }
+              ]
+            },
+            {
+              "precondition": {
+                "method": "equals",
+                "fieldName": "MSH-4-2",
+                "fieldValue": "AUSTIN",
+                "order": 1
+              },
+              "operationList": [
+                {
+                  "method": "set",
+                  "destinationField": "MSH-21-2",
+                  "setValue": "CDCPHINVS",
+                  "order": 1
+                },
+                {
+                  "method": "set",
+                  "destinationField": "MSH-21-1",
+                  "setValue": "Z22",
+                  "order": 0
+                }
+              ]
+            }
+          ],
+          "responseTransformations": [
+            {
+              "precondition": {
+                "method": "equals",
+                "fieldName": "MSA-1-1",
+                "fieldValue": "AA",
+                "order": 0
+              },
+              "operationList": [
+                {
+                  "method": "set",
+                  "destinationField": "MSA-1-1",
+                  "setValue": "CA",
+                  "order": 1
+                }
+              ]
+            },
+            {
+              "precondition": {
+                "method": "equals",
+                "fieldName": "MSA-1-1",
+                "fieldValue": "AE",
+                "order": 0
+              },
+              "operationList": [
+                {
+                  "method": "set",
+                  "destinationField": "MSA-1-1",
+                  "setValue": "CE",
+                  "order": 1
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "pipelineName": "org1_p2",
+          "inboundEndpoint": "rest/transform",
+          "outboundEndpoint": null,
+          "requestTransformations": [],
+          "responseTransformations": []
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add code that was used for demo to team on 2May2024.  JSON configuration read in to ServiceConfig object by ServiceConfigLoader as application runs.

When message received via /transform information (organization, inbound endpoint, outbound endpoint) is read from headers to determine the pipelines to run.  Obviously this will change to proper handling.  A ServiceContext is created from this information.  Then a PipelineChain built from the context.  The Pipeline's are then executed on the incoming message.  The transformed message is then submitted through a temporary MllpSender.  The response from the downstream system is then transformed via the Pipeline before sending back to the caller.

A pipeline is made up Request Transformations and Response Transformations.  Each transformation is made up of a precondition operation that must execute true before any changes are made.  Then there is also a chain of Operations which make up the steps executed to transform data.