### PR TITLE
IGDD-1718 - Update GitHub action for new Xform Service ECS Cluster

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -167,7 +167,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: transformation-service
         run: |
-          aws ecs update-service --cluster izgateway-dev-izgateway-services --service izgw-xform-dev --force-new-deployment --enable-execute-command --desired-count 1 | jq ".service.deployments[].id"
+          aws ecs update-service --cluster xform-service-dev --service xform-service-dev --force-new-deployment --enable-execute-command --desired-count 1 | jq ".service.deployments[].id"
 
       - name: Login to GitHub Repository
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Upate GitHub action so that the xform-service-dev cluster in AWS is updated instead of how Xform Service used to run inside the IZG Hub ECS Cluster.