### PR TITLE
IGDD-1778 FHIR tests for postman

### DIFF
--- a/src/main/java/gov/cdc/izgateway/xform/endpoints/fhir/FhirController.java
+++ b/src/main/java/gov/cdc/izgateway/xform/endpoints/fhir/FhirController.java
@@ -1,5 +1,6 @@
 package gov.cdc.izgateway.xform.endpoints.fhir;
 
+import gov.cdc.izgateway.security.AccessControlRegistry;
 import gov.cdc.izgw.v2tofhir.converter.MessageParser;
 import gov.cdc.izgw.v2tofhir.datatype.HumanNameParser;
 import gov.cdc.izgw.v2tofhir.segment.PIDParser;
@@ -47,6 +48,7 @@ import org.hl7.fhir.r4.model.StringType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -126,6 +128,7 @@ import lombok.extern.slf4j.Slf4j;
 @RolesAllowed({Roles.SOAP, Roles.ADMIN})
 @RequestMapping("/fhir")
 @Slf4j
+@Lazy(false)
 public class FhirController {
 
 	/**
@@ -157,9 +160,10 @@ public class FhirController {
 	 * @param hub	The hub controller to talk to.
 	 * @param config The configuration for the converter
 	 */
-	public FhirController(@Autowired HubController hub, FhirConfiguration config) {
+	public FhirController(@Autowired HubController hub, FhirConfiguration config, AccessControlRegistry registry) {
 		this.hub = hub;
 		this.config = config;
+        registry.register(this);
 	}
 	
     /**

--- a/testing/configuration/organizations.json
+++ b/testing/configuration/organizations.json
@@ -9,6 +9,11 @@
   "active" : true,
   "commonName" : "pcahill.testing.izgateway.org"
 }, {
+  "organizationName" : "Starfleet Medical Systems",
+  "id" : "0d15449b-fb08-4013-8985-20c148b353fe",
+  "active" : true,
+  "commonName" : "sampleSubject"
+}, {
   "organizationName" : "Cosmic Ray Immunization Center (localhost)",
   "id" : "a10bb561-5d7b-4ec7-84c5-b6fa73efe562",
   "active" : true,

--- a/testing/configuration/solutions.json
+++ b/testing/configuration/solutions.json
@@ -40,8 +40,8 @@
       "method" : "set",
       "id" : "c995f9f1-7cca-4b01-a1fa-1087a35d5502",
       "order" : 0,
-      "destinationField" : "/MSH-7-1",
-      "setValue" : "MSH 7 NEW VALUE"
+      "destinationField" : "/MSH-22-1",
+      "setValue" : "MSH 22 NEW VALUE 4"
     } ]
   } ]
 }, {
@@ -118,8 +118,8 @@
       "method" : "set",
       "id" : "ef3eb737-0cf2-44cc-8608-84e7017e5c27",
       "order" : 0,
-      "destinationField" : "/MSX-7-1",
-      "setValue" : "MSH 7 NEW VALUE"
+      "destinationField" : "/MSX-22-1",
+      "setValue" : "MSH 22 NEW VALUE"
     } ]
   } ]
 }, {
@@ -170,7 +170,7 @@
   "responseOperations" : [ ]
 }, {
   "id" : "bf3326fe-ab52-4d6c-b37f-7db5f1769c4c",
-  "solutionName" : "POSTMAN MSH-7-1 Response Transformer - DO NOT DELETE",
+  "solutionName" : "POSTMAN MSH-22-1 Response Transformer - DO NOT DELETE",
   "description" : "Used in Postman Tests",
   "version" : "1.0",
   "active" : true,
@@ -184,8 +184,8 @@
       "method" : "set",
       "id" : "6f750e31-3b60-49bc-a01e-1c2d8b84e3db",
       "order" : 0,
-      "destinationField" : "/MSH-7-1",
-      "setValue" : "MSH 7 NEW VALUE"
+      "destinationField" : "/MSH-22-1",
+      "setValue" : "MSH 22 NEW VALUE"
     } ]
   } ]
 }, {

--- a/testing/configuration/solutions.json
+++ b/testing/configuration/solutions.json
@@ -170,7 +170,7 @@
   "responseOperations" : [ ]
 }, {
   "id" : "bf3326fe-ab52-4d6c-b37f-7db5f1769c4c",
-  "solutionName" : "POSTMAN MSH-22-1 Response Transformer - DO NOT DELETE",
+  "solutionName" : "POSTMAN MSH-19-1 Response Transformer - DO NOT DELETE",
   "description" : "Used in Postman Tests",
   "version" : "1.0",
   "active" : true,
@@ -184,8 +184,8 @@
       "method" : "set",
       "id" : "6f750e31-3b60-49bc-a01e-1c2d8b84e3db",
       "order" : 0,
-      "destinationField" : "/MSH-22-1",
-      "setValue" : "MSH 22 NEW VALUE"
+      "destinationField" : "/MSH-19-1",
+      "setValue" : "MSH 19 NEW VALUE"
     } ]
   } ]
 }, {

--- a/testing/scripts/TS_Integration_Test.postman_collection.json
+++ b/testing/scripts/TS_Integration_Test.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "d6c9c438-f003-40b1-ace9-518df0030333",
+		"_postman_id": "ceb75421-eb48-40f2-a4e5-3c3ec8b1bfff",
 		"name": "TS Integration Test",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "28864196"
@@ -25,10 +25,10 @@
 											"    pm.response.to.have.status(200);\r",
 											"});\r",
 											"\r",
-											"pm.test(\"MSH-7 in the response message has been transformed\", function () {\r",
+											"pm.test(\"MSH-19 in the response message has been transformed\", function () {\r",
 											"    var response = utils.removeNS(xml2Json(responseBody));\r",
 											"    var hl7Message = response['Envelope']['Body']['SubmitSingleMessageResponse']['Hl7Message'];\r",
-											"    pm.expect(utils.hl7Terser(hl7Message, 'MSH', 7, 1)).to.eql('MSH 7 NEW VALUE');\r",
+											"    pm.expect(utils.hl7Terser(hl7Message, 'MSH', 19, 1)).to.eql('MSH 19 NEW VALUE');\r",
 											"\r",
 											"\r",
 											"});\r",
@@ -698,10 +698,10 @@
 											"    pm.response.to.have.status(200);\r",
 											"});\r",
 											"\r",
-											"pm.test(\"MSH-7 in the response message has been transformed\", function () {\r",
+											"pm.test(\"MSH-19 in the response message has been transformed\", function () {\r",
 											"    var response = utils.removeNS(xml2Json(responseBody));\r",
 											"    var hl7Message = response['Envelope']['Body']['SubmitSingleMessageResponse']['Hl7Message'];\r",
-											"    pm.expect(utils.hl7Terser(hl7Message, 'MSH', 7, 1)).to.eql('MSH 7 NEW VALUE');\r",
+											"    pm.expect(utils.hl7Terser(hl7Message, 'MSH', 19, 1)).to.eql('MSH 19 NEW VALUE');\r",
 											"\r",
 											"\r",
 											"});\r",
@@ -1083,10 +1083,10 @@
 									"    pm.response.to.have.status(200);\r",
 									"});\r",
 									"\r",
-									"pm.test(\"MSH-7 in the response message has been transformed\", function () {\r",
+									"pm.test(\"MSH-19 in the response message has been transformed\", function () {\r",
 									"    var response = utils.removeNS(xml2Json(responseBody));\r",
 									"    var hl7Message = response['Envelope']['Body']['SubmitSingleMessageResponse']['Hl7Message'];\r",
-									"    pm.expect(utils.hl7Terser(hl7Message, 'MSH', 7, 1)).to.eql('MSH 7 NEW VALUE');\r",
+									"    pm.expect(utils.hl7Terser(hl7Message, 'MSH', 19, 1)).to.eql('MSH 19 NEW VALUE');\r",
 									"\r",
 									"\r",
 									"});\r",
@@ -1531,10 +1531,10 @@
 									"    pm.response.to.have.status(200);\r",
 									"});\r",
 									"\r",
-									"pm.test(\"MSH-7 in the response message has been transformed\", function () {\r",
+									"pm.test(\"MSH-19 in the response message has been transformed\", function () {\r",
 									"    var response = utils.removeNS(xml2Json(responseBody));\r",
 									"    var hl7Message = response['Envelope']['Body']['SubmitSingleMessageResponse']['Hl7Message'];\r",
-									"    pm.expect(utils.hl7Terser(hl7Message, 'MSH', 7, 1)).to.eql('MSH 7 NEW VALUE');\r",
+									"    pm.expect(utils.hl7Terser(hl7Message, 'MSH', 19, 1)).to.eql('MSH 19 NEW VALUE');\r",
 									"\r",
 									"\r",
 									"});\r",
@@ -23751,54 +23751,6 @@
 		},
 		{
 			"key": "hex1b",
-			"value": ""
-		},
-		{
-			"key": "currentName",
-			"value": ""
-		},
-		{
-			"key": "currentId",
-			"value": ""
-		},
-		{
-			"key": "currentOrganizationId",
-			"value": ""
-		},
-		{
-			"key": "currentInboundEndpoint",
-			"value": ""
-		},
-		{
-			"key": "currentOutboundEndpoint",
-			"value": ""
-		},
-		{
-			"key": "currentActive",
-			"value": ""
-		},
-		{
-			"key": "createdPipeline",
-			"value": ""
-		},
-		{
-			"key": "currentCodeSystem",
-			"value": ""
-		},
-		{
-			"key": "currentCode",
-			"value": ""
-		},
-		{
-			"key": "currentTargetCodeSystem",
-			"value": ""
-		},
-		{
-			"key": "currentTargetCode",
-			"value": ""
-		},
-		{
-			"key": "createdMapping",
 			"value": ""
 		},
 		{

--- a/testing/scripts/TS_Integration_Test.postman_collection.json
+++ b/testing/scripts/TS_Integration_Test.postman_collection.json
@@ -1443,7 +1443,7 @@
 					"response": []
 				},
 				{
-					"name": "TS_TC_07 FHIR Query Returns No Data",
+					"name": "TS_TC_08 FHIR Query Returns No Data",
 					"event": [
 						{
 							"listen": "test",

--- a/testing/scripts/TS_Integration_Test.postman_collection.json
+++ b/testing/scripts/TS_Integration_Test.postman_collection.json
@@ -1361,6 +1361,163 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "TS_TC_07 FHIR Query Returns Data",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"let response = pm.response.json();",
+									"pm.test(\"verify type is Bundle\", function() {",
+									"    pm.expect(response.resourceType).to.equal(\"Bundle\");",
+									"});",
+									"",
+									"pm.test(\"Verify Entry length is 4\", function() {",
+									"    pm.expect(response.entry.length).to.equal(4);",
+									"});",
+									"",
+									"pm.test(\"Verify Immunization Code\", function() {",
+									"    pm.expect(response.entry[3].resource.resourceType).to.equal(\"Immunization\");",
+									"});",
+									"",
+									"pm.test(\"Verify Vaccine Code\", function() {",
+									"    pm.expect(response.entry[3].resource.vaccineCode.coding[0].code).to.equal(\"208\");",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "",
+								"value": "",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "patient.given",
+									"value": "{{fhirPatientGiven}}",
+									"type": "text"
+								},
+								{
+									"key": "patient.family",
+									"value": "{{fhirPateintFamily}}",
+									"type": "text"
+								},
+								{
+									"key": "patient.birthdate",
+									"value": "{{fhirPatientDOB}}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}:{{port}}/fhir/dev/Immunization",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"fhir",
+								"dev",
+								"Immunization"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "TS_TC_07 FHIR Query Returns No Data",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"let response = pm.response.json();",
+									"pm.test(\"verify type is Bundle\", function() {",
+									"    pm.expect(response.resourceType).to.equal(\"Bundle\");",
+									"});",
+									"",
+									"pm.test(\"Verify Entry length is 2\", function() {",
+									"    pm.expect(response.entry.length).to.equal(2);",
+									"});",
+									"",
+									"pm.test(\"Verify NF is returned indicating no data found\", function() {",
+									"    pm.expect(response.entry[1].resource.issue[0].details.coding[0].code).to.equal(\"NF\");",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "",
+								"value": "",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "patient.given",
+									"value": "Nogiven",
+									"type": "text"
+								},
+								{
+									"key": "patient.family",
+									"value": "Nofamily",
+									"type": "text"
+								},
+								{
+									"key": "patient.birthdate",
+									"value": "1900-01-01",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}:{{port}}/fhir/dev/Immunization",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"fhir",
+								"dev",
+								"Immunization"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},
@@ -22112,6 +22269,11 @@
 					"};",
 					"pm.collectionVariables.set(\"validJwtNoRoles\", JSON.stringify(validJwtNoRoles));",
 					"",
+					"// FHIR Tests",
+					"pm.collectionVariables.set(\"fhirPatientGiven\", \"MarnyAIRA\");",
+					"pm.collectionVariables.set(\"fhirPatientFamily\", \"CuyahogaAIRA\");",
+					"pm.collectionVariables.set(\"fhirPatientDOB\", \"1960-05-07\");",
+					"",
 					"var tooLarge = goodResponse.replace('&|', \"&amp;|\");",
 					"var last;",
 					"var maxLength = 65536;",
@@ -23390,6 +23552,18 @@
 		},
 		{
 			"key": "createdMapping",
+			"value": ""
+		},
+		{
+			"key": "fhirPatientGiven",
+			"value": ""
+		},
+		{
+			"key": "fhirPatientFamily",
+			"value": ""
+		},
+		{
+			"key": "fhirPatientDOB",
 			"value": ""
 		}
 	]

--- a/testing/scripts/TS_Integration_Test.postman_collection.json
+++ b/testing/scripts/TS_Integration_Test.postman_collection.json
@@ -820,6 +820,253 @@
 								}
 							},
 							"response": []
+						},
+						{
+							"name": "TS_TC_07 FHIR Query Returns Data with JWT",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"let response = pm.response.json();",
+											"pm.test(\"verify type is Bundle\", function() {",
+											"    pm.expect(response.resourceType).to.equal(\"Bundle\");",
+											"});",
+											"",
+											"pm.test(\"Verify Entry length is 4\", function() {",
+											"    pm.expect(response.entry.length).to.equal(4);",
+											"});",
+											"",
+											"pm.test(\"Verify Immunization Code\", function() {",
+											"    pm.expect(response.entry[3].resource.resourceType).to.equal(\"Immunization\");",
+											"});",
+											"",
+											"pm.test(\"Verify Vaccine Code\", function() {",
+											"    pm.expect(response.entry[3].resource.vaccineCode.coding[0].code).to.equal(\"208\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "payload",
+											"value": "{{validJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "",
+										"value": "",
+										"type": "text",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "urlencoded",
+									"urlencoded": [
+										{
+											"key": "patient.given",
+											"value": "{{fhirPatientGiven}}",
+											"type": "text"
+										},
+										{
+											"key": "patient.family",
+											"value": "{{fhirPateintFamily}}",
+											"type": "text"
+										},
+										{
+											"key": "patient.birthdate",
+											"value": "{{fhirPatientDOB}}",
+											"type": "text"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/fhir/dev/Immunization",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"fhir",
+										"dev",
+										"Immunization"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "TS_TC_08 FHIR Query Returns No Data with JWT",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"let response = pm.response.json();",
+											"pm.test(\"verify type is Bundle\", function() {",
+											"    pm.expect(response.resourceType).to.equal(\"Bundle\");",
+											"});",
+											"",
+											"pm.test(\"Verify Entry length is 2\", function() {",
+											"    pm.expect(response.entry.length).to.equal(2);",
+											"});",
+											"",
+											"pm.test(\"Verify NF is returned indicating no data found\", function() {",
+											"    pm.expect(response.entry[1].resource.issue[0].details.coding[0].code).to.equal(\"NF\");",
+											"});",
+											"",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "payload",
+											"value": "{{validJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "",
+										"value": "",
+										"type": "text",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "urlencoded",
+									"urlencoded": [
+										{
+											"key": "patient.given",
+											"value": "Nogiven",
+											"type": "text"
+										},
+										{
+											"key": "patient.family",
+											"value": "Nofamily",
+											"type": "text"
+										},
+										{
+											"key": "patient.birthdate",
+											"value": "1900-01-01",
+											"type": "text"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/fhir/dev/Immunization",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"fhir",
+										"dev",
+										"Immunization"
+									]
+								}
+							},
+							"response": []
 						}
 					]
 				},


### PR DESCRIPTION
src/main/java/gov/cdc/izgateway/xform/endpoints/fhir/FhirController.java
 - Added FHIR endpoint to AccessControlRegistry

testing/configuration/organizations.json
 - added sampleSubject (from JWT) to the list of orgs
 
testing/configuration/solutions.json
 - changed solution to use MSH-22 instead of MSH-7 for "set" operation.  MSH-22 supports strings and MSH-7 does not which caused issues with the FHIR processing.
 
testing/scripts/TS_Integration_Test.postman_collection.json
 - added tests for the FHIR endpoint. 
