### PR TITLE
IGDD-1417 - Changes for updated JWT validation in izgw-core 2.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
 		<dependency>
 			<groupId>gov.cdc.izgw</groupId>
 			<artifactId>izgw-core</artifactId>
-			<version>2.1.7-izgw-core-SNAPSHOT</version>
+			<version>2.1.8-izgw-core-SNAPSHOT</version>
 		</dependency>
 		<!--
 		 izgw-core 2.1.2 pulls in org.springframework.boot:spring-boot-starter-security:jar:3.3.4

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,9 +18,12 @@ xform:
     operation-precondition-fields: testing/configuration/operation-precondition-fields.json
     users: testing/configuration/users.json
     group-role-mapping: testing/configuration/group-role-mapping.json
-  access-control-enabled: ${XFORM_ACCESS_CONTROL_ENABLED:false}
 jwt:
+  provider: ${XFORM_JWT_PROVIDER:shared-secret}
   shared-secret: ${XFORM_JWT_SECRET:}
+  jwk-set-uri: ${XFORM_JWT_URI:}
+  roles-claim: ${XFORM_JWT_ROLES_CLAIM:roles}
+  scopes-claim: ${XFORM_JWT_SCOPES_CLAIM:scope}
 
 spring:
   autoconfigure:

--- a/testing/configuration/group-role-mapping.json
+++ b/testing/configuration/group-role-mapping.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "fe65c254-eeee-4d41-a81c-187847a10dd0",
-    "groupName": "Admin",
+    "groupName": "Xform Admin",
     "active": true,
     "roles": [
       "pipeline-reader",
@@ -12,18 +12,67 @@
       "solution-deleter",
       "organization-reader",
       "organization-writer",
-      "organization-deleter"
+      "organization-deleter",
+      "admin"
     ]
   },
   {
     "id": "fe65c254-bbbb-4d41-a81c-187847a10dd0",
-    "groupName": "BusinessAnalyst",
+    "groupName": "Xform Business Analyst",
     "active": true,
     "roles": [
       "pipeline-reader",
       "pipeline-writer",
       "pipeline-deleter",
       "organization-reader"
+    ]
+  },
+  {
+    "id": "a3c729dd-4f0e-48c7-a6a6-18c66f8cba93",
+    "groupName": "Xform Solutions Engineer",
+    "active": true,
+    "roles": [
+      "pipeline-reader",
+      "pipeline-writer",
+      "pipeline-deleter",
+      "solution-reader",
+      "solution-writer",
+      "solution-deleter",
+      "organization-reader",
+      "organization-writer"
+    ]
+  },
+  {
+    "id": "6c31247a-9195-4d23-b203-12dfb485ad10",
+    "groupName": "Xform Onboarding Staff",
+    "active": true,
+    "roles": [
+      "pipeline-reader",
+      "solution-reader",
+      "organization-reader"
+    ]
+  },
+  {
+    "id": "86eb1912-b46d-435e-85e5-64d63853ffc6",
+    "groupName": "Xform Operations Staff",
+    "active": true,
+    "roles": [
+      "pipeline-reader",
+      "pipeline-writer",
+      "pipeline-deleter",
+      "solution-reader",
+      "solution-writer",
+      "solution-deleter",
+      "organization-reader",
+      "organization-writer"
+    ]
+  },
+  {
+    "id": "7b23ee9e-ba1a-43f7-9290-2b6a3dccaf32",
+    "groupName": "Xform Sender",
+    "active": true,
+    "roles": [
+      "xform-sender"
     ]
   }
 ]

--- a/testing/configuration/mappings.json
+++ b/testing/configuration/mappings.json
@@ -1,38 +1,33 @@
-[
-  {
-    "id": "e69ea576-045f-43a1-8472-ad090ca8655b",
-    "active" : true,
-    "organizationId": "0d15449b-fb08-4013-8985-20c148b353fe",
-    "codeSystem": "CDCREC",
-    "code": "2106-3",
-    "targetCodeSystem": "CDCREC3",
-    "targetCode": "NEWCODE!"
-  },
-  {
-    "id": "e69ea576-045f-43a1-8472-ad090ca8655b",
-    "active" : true,
-    "organizationId": "d339cd15-2e57-4456-94b6-1e14f079a0de",
-    "codeSystem": "CDCREC",
-    "code": "2106-3",
-    "targetCodeSystem": "CDCREC3",
-    "targetCode": "NEWCODE!"
-  },
-  {
-    "id": "8a169c1d-cee5-41e0-94f4-1300c41842ff",
-    "active" : true,
-    "organizationId": "0d15449b-fb08-4013-8985-20c148b353fe",
-    "codeSystem": "MYCODESYSTEM",
-    "code": "UNKNOWN2",
-    "targetCodeSystem": "CDCREC",
-    "targetCode": "NEWCODE2"
-  },
-  {
-    "id": "e2f1c811-b8d3-455a-8c7e-521e5929a884",
-    "active" : true,
-    "organizationId": "19c3dd20-31f4-4508-87ee-705fca9603b3",
-    "codeSystem": "MYCODESYSTEM2",
-    "code": "UNKNOWN",
-    "targetCodeSystem": "CDCREC",
-    "targetCode": "NEWCODE3"
-  }
-]
+[ {
+  "id" : "e69ea576-045f-43a1-8472-ad090ca8655b",
+  "active" : true,
+  "organizationId" : "0d15449b-fb08-4013-8985-20c148b353fe",
+  "codeSystem" : "CDCREC",
+  "code" : "2106-3",
+  "targetCodeSystem" : "CDCREC3",
+  "targetCode" : "NEWCODE!"
+}, {
+  "id" : "e69ea576-045f-43a1-8472-ad090ca8655b",
+  "active" : true,
+  "organizationId" : "d339cd15-2e57-4456-94b6-1e14f079a0de",
+  "codeSystem" : "CDCREC",
+  "code" : "2106-3",
+  "targetCodeSystem" : "CDCREC3",
+  "targetCode" : "NEWCODE!"
+}, {
+  "id" : "8a169c1d-cee5-41e0-94f4-1300c41842ff",
+  "active" : true,
+  "organizationId" : "0d15449b-fb08-4013-8985-20c148b353fe",
+  "codeSystem" : "MYCODESYSTEM",
+  "code" : "UNKNOWN2",
+  "targetCodeSystem" : "CDCREC",
+  "targetCode" : "NEWCODE2"
+}, {
+  "id" : "e2f1c811-b8d3-455a-8c7e-521e5929a884",
+  "active" : true,
+  "organizationId" : "19c3dd20-31f4-4508-87ee-705fca9603b3",
+  "codeSystem" : "MYCODESYSTEM2",
+  "code" : "UNKNOWN",
+  "targetCodeSystem" : "CDCREC",
+  "targetCode" : "NEWCODE3"
+} ]

--- a/testing/scripts/TS_Integration_Test.postman_collection.json
+++ b/testing/scripts/TS_Integration_Test.postman_collection.json
@@ -1,9 +1,10 @@
 {
 	"info": {
-		"_postman_id": "ceb75421-eb48-40f2-a4e5-3c3ec8b1bfff",
+		"_postman_id": "c2b24de5-ec02-4164-8a50-22ac219c9af8",
 		"name": "TS Integration Test",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "28864196"
+		"_exporter_id": "2729094",
+		"_collection_link": "https://lively-space-957471.postman.co/workspace/IZG~107100cc-f7df-4edf-97fa-f5e0022afeca/collection/2729094-c2b24de5-ec02-4164-8a50-22ac219c9af8?action=share&source=collection_link&creator=2729094"
 	},
 	"item": [
 		{
@@ -22469,6 +22470,2357 @@
 					"response": []
 				}
 			]
+		},
+		{
+			"name": "JWT Validation",
+			"item": [
+				{
+					"name": "JWT Timestamp Validation",
+					"item": [
+						{
+							"name": "All timestamps present & valid",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var validJwt = {",
+											"  \"iss\": \"theIssuer\",",
+											"  \"sub\": \"sampleSubject\",",
+											"  \"aud\": \"theAudience\",",
+											"  \"jti\": \"jwt-id-001\",",
+											"  \"scope\": \"organization-reader\",",
+											"  \"iat\": Math.floor(Date.now() / 1000),",
+											"  \"nbf\": Math.floor(Date.now() / 1000),",
+											"  \"exp\": Math.floor(Date.now() / 1000) + (60 * 60)",
+											"};",
+											"pm.variables.set(\"localJwt\", JSON.stringify(validJwt));",
+											"",
+											"pm.variables.set(\"expectedHttpCode\", 200);"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let expectedCode = pm.variables.get(\"expectedHttpCode\");",
+											"",
+											"pm.test(\"Status code is \" + expectedCode, function () {",
+											"    pm.response.to.have.status(expectedCode);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"strictSSL": false,
+								"tlsDisabledProtocols": []
+							},
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "payload",
+											"value": "{{localJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "nextCursor",
+										"value": "0d15449b-fb08-4013-8985-20c148b353ab",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/api/v1/organizations?includeInactive=true&limit=100000",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"api",
+										"v1",
+										"organizations"
+									],
+									"query": [
+										{
+											"key": "includeInactive",
+											"value": "true"
+										},
+										{
+											"key": "limit",
+											"value": "100000"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Missing IAT",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var validJwt = {",
+											"  \"iss\": \"theIssuer\",",
+											"  \"sub\": \"sampleSubject\",",
+											"  \"aud\": \"theAudience\",",
+											"  \"jti\": \"jwt-id-001\",",
+											"  \"scope\": \"organization-reader\",",
+											"  \"nbf\": Math.floor(Date.now() / 1000),",
+											"  \"exp\": Math.floor(Date.now() / 1000) + (60 * 60)",
+											"};",
+											"pm.variables.set(\"localJwt\", JSON.stringify(validJwt));",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"strictSSL": false,
+								"tlsDisabledProtocols": []
+							},
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "payload",
+											"value": "{{localJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "nextCursor",
+										"value": "0d15449b-fb08-4013-8985-20c148b353ab",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/api/v1/organizations?includeInactive=true&limit=100000",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"api",
+										"v1",
+										"organizations"
+									],
+									"query": [
+										{
+											"key": "includeInactive",
+											"value": "true"
+										},
+										{
+											"key": "limit",
+											"value": "100000"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Missing NBF",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var validJwt = {",
+											"  \"iss\": \"theIssuer\",",
+											"  \"sub\": \"sampleSubject\",",
+											"  \"aud\": \"theAudience\",",
+											"  \"jti\": \"jwt-id-001\",",
+											"  \"scope\": \"organization-reader\",",
+											"  \"iat\": Math.floor(Date.now() / 1000),",
+											"  \"exp\": Math.floor(Date.now() / 1000) + (60 * 60)",
+											"};",
+											"pm.variables.set(\"localJwt\", JSON.stringify(validJwt));",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"strictSSL": false,
+								"tlsDisabledProtocols": []
+							},
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "payload",
+											"value": "{{localJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "nextCursor",
+										"value": "0d15449b-fb08-4013-8985-20c148b353ab",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/api/v1/organizations?includeInactive=true&limit=100000",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"api",
+										"v1",
+										"organizations"
+									],
+									"query": [
+										{
+											"key": "includeInactive",
+											"value": "true"
+										},
+										{
+											"key": "limit",
+											"value": "100000"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Missing IAT & NBF",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var validJwt = {",
+											"  \"iss\": \"theIssuer\",",
+											"  \"sub\": \"sampleSubject\",",
+											"  \"aud\": \"theAudience\",",
+											"  \"jti\": \"jwt-id-001\",",
+											"  \"scope\": \"organization-reader\",",
+											"  \"exp\": Math.floor(Date.now() / 1000) + (60 * 60)",
+											"};",
+											"pm.variables.set(\"localJwt\", JSON.stringify(validJwt));",
+											"",
+											"pm.variables.set(\"expectedHttpCode\", 401);",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let expectedCode = pm.variables.get(\"expectedHttpCode\");",
+											"",
+											"pm.test(\"Status code is \" + expectedCode, function () {",
+											"    pm.response.to.have.status(expectedCode);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"strictSSL": false,
+								"tlsDisabledProtocols": []
+							},
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "payload",
+											"value": "{{localJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "nextCursor",
+										"value": "0d15449b-fb08-4013-8985-20c148b353ab",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/api/v1/organizations?includeInactive=true&limit=100000",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"api",
+										"v1",
+										"organizations"
+									],
+									"query": [
+										{
+											"key": "includeInactive",
+											"value": "true"
+										},
+										{
+											"key": "limit",
+											"value": "100000"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Missing All Timestamps",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var validJwt = {",
+											"  \"iss\": \"theIssuer\",",
+											"  \"sub\": \"sampleSubject\",",
+											"  \"aud\": \"theAudience\",",
+											"  \"jti\": \"jwt-id-001\",",
+											"  \"scope\": \"organization-reader\"",
+											"};",
+											"pm.variables.set(\"localJwt\", JSON.stringify(validJwt));",
+											"",
+											"pm.variables.set(\"expectedHttpCode\", 401);"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let expectedCode = pm.variables.get(\"expectedHttpCode\");",
+											"",
+											"pm.test(\"Status code is \" + expectedCode, function () {",
+											"    pm.response.to.have.status(expectedCode);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"strictSSL": false,
+								"tlsDisabledProtocols": []
+							},
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "payload",
+											"value": "{{localJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "nextCursor",
+										"value": "0d15449b-fb08-4013-8985-20c148b353ab",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/api/v1/organizations?includeInactive=true&limit=100000",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"api",
+										"v1",
+										"organizations"
+									],
+									"query": [
+										{
+											"key": "includeInactive",
+											"value": "true"
+										},
+										{
+											"key": "limit",
+											"value": "100000"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Expired EXP",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var validJwt = {",
+											"  \"iss\": \"theIssuer\",",
+											"  \"sub\": \"sampleSubject\",",
+											"  \"aud\": \"theAudience\",",
+											"  \"jti\": \"jwt-id-001\",",
+											"  \"scope\": \"organization-reader\",",
+											"  \"iat\": Math.floor(Date.now() / 1000),",
+											"  \"nbf\": Math.floor(Date.now() / 1000),",
+											"  \"exp\": Math.floor(Date.now() / 1000) - (60 * 60)",
+											"};",
+											"pm.variables.set(\"localJwt\", JSON.stringify(validJwt));",
+											"",
+											"pm.variables.set(\"expectedHttpCode\", 401);"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let expectedCode = pm.variables.get(\"expectedHttpCode\");",
+											"",
+											"pm.test(\"Status code is \" + expectedCode, function () {",
+											"    pm.response.to.have.status(expectedCode);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"strictSSL": false,
+								"tlsDisabledProtocols": []
+							},
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "payload",
+											"value": "{{localJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "nextCursor",
+										"value": "0d15449b-fb08-4013-8985-20c148b353ab",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/api/v1/organizations?includeInactive=true&limit=100000",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"api",
+										"v1",
+										"organizations"
+									],
+									"query": [
+										{
+											"key": "includeInactive",
+											"value": "true"
+										},
+										{
+											"key": "limit",
+											"value": "100000"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Future IAT",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var validJwt = {",
+											"  \"iss\": \"theIssuer\",",
+											"  \"sub\": \"sampleSubject\",",
+											"  \"aud\": \"theAudience\",",
+											"  \"jti\": \"jwt-id-001\",",
+											"  \"scope\": \"organization-reader\",",
+											"  \"iat\": Math.floor(Date.now() / 1000) + (30 * 60),",
+											"  \"nbf\": Math.floor(Date.now() / 1000),",
+											"  \"exp\": Math.floor(Date.now() / 1000) + (60 * 60)",
+											"};",
+											"pm.variables.set(\"localJwt\", JSON.stringify(validJwt));",
+											"",
+											"pm.variables.set(\"expectedHttpCode\", 401);"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let expectedCode = pm.variables.get(\"expectedHttpCode\");",
+											"",
+											"pm.test(\"Status code is \" + expectedCode, function () {",
+											"    pm.response.to.have.status(expectedCode);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"strictSSL": false,
+								"tlsDisabledProtocols": []
+							},
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "payload",
+											"value": "{{localJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "nextCursor",
+										"value": "0d15449b-fb08-4013-8985-20c148b353ab",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/api/v1/organizations?includeInactive=true&limit=100000",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"api",
+										"v1",
+										"organizations"
+									],
+									"query": [
+										{
+											"key": "includeInactive",
+											"value": "true"
+										},
+										{
+											"key": "limit",
+											"value": "100000"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Future NBF",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var validJwt = {",
+											"  \"iss\": \"theIssuer\",",
+											"  \"sub\": \"sampleSubject\",",
+											"  \"aud\": \"theAudience\",",
+											"  \"jti\": \"jwt-id-001\",",
+											"  \"scope\": \"organization-reader\",",
+											"  \"iat\": Math.floor(Date.now() / 1000),",
+											"  \"nbf\": Math.floor(Date.now() / 1000) + (30 * 60),",
+											"  \"exp\": Math.floor(Date.now() / 1000) + (60 * 60)",
+											"};",
+											"pm.variables.set(\"localJwt\", JSON.stringify(validJwt));",
+											"",
+											"pm.variables.set(\"expectedHttpCode\", 401);"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let expectedCode = pm.variables.get(\"expectedHttpCode\");",
+											"",
+											"pm.test(\"Status code is \" + expectedCode, function () {",
+											"    pm.response.to.have.status(expectedCode);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"strictSSL": false,
+								"tlsDisabledProtocols": []
+							},
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "payload",
+											"value": "{{localJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "nextCursor",
+										"value": "0d15449b-fb08-4013-8985-20c148b353ab",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/api/v1/organizations?includeInactive=true&limit=100000",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"api",
+										"v1",
+										"organizations"
+									],
+									"query": [
+										{
+											"key": "includeInactive",
+											"value": "true"
+										},
+										{
+											"key": "limit",
+											"value": "100000"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "IAT after EXP",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var validJwt = {",
+											"  \"iss\": \"theIssuer\",",
+											"  \"sub\": \"sampleSubject\",",
+											"  \"aud\": \"theAudience\",",
+											"  \"jti\": \"jwt-id-001\",",
+											"  \"scope\": \"organization-reader\",",
+											"  \"iat\": Math.floor(Date.now() / 1000) + (90 * 60),",
+											"  \"nbf\": Math.floor(Date.now() / 1000),",
+											"  \"exp\": Math.floor(Date.now() / 1000) + (60 * 60)",
+											"};",
+											"pm.variables.set(\"localJwt\", JSON.stringify(validJwt));",
+											"",
+											"pm.variables.set(\"expectedHttpCode\", 401);"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let expectedCode = pm.variables.get(\"expectedHttpCode\");",
+											"",
+											"pm.test(\"Status code is \" + expectedCode, function () {",
+											"    pm.response.to.have.status(expectedCode);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"strictSSL": false,
+								"tlsDisabledProtocols": []
+							},
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "payload",
+											"value": "{{localJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "nextCursor",
+										"value": "0d15449b-fb08-4013-8985-20c148b353ab",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/api/v1/organizations?includeInactive=true&limit=100000",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"api",
+										"v1",
+										"organizations"
+									],
+									"query": [
+										{
+											"key": "includeInactive",
+											"value": "true"
+										},
+										{
+											"key": "limit",
+											"value": "100000"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "NBF after EXP",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var validJwt = {",
+											"  \"iss\": \"theIssuer\",",
+											"  \"sub\": \"sampleSubject\",",
+											"  \"aud\": \"theAudience\",",
+											"  \"jti\": \"jwt-id-001\",",
+											"  \"scope\": \"organization-reader\",",
+											"  \"iat\": Math.floor(Date.now() / 1000),",
+											"  \"nbf\": Math.floor(Date.now() / 1000) + (90 * 60),",
+											"  \"exp\": Math.floor(Date.now() / 1000) + (60 * 60)",
+											"};",
+											"pm.variables.set(\"localJwt\", JSON.stringify(validJwt));",
+											"",
+											"pm.variables.set(\"expectedHttpCode\", 401);"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let expectedCode = pm.variables.get(\"expectedHttpCode\");",
+											"",
+											"pm.test(\"Status code is \" + expectedCode, function () {",
+											"    pm.response.to.have.status(expectedCode);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"strictSSL": false,
+								"tlsDisabledProtocols": []
+							},
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "payload",
+											"value": "{{localJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "nextCursor",
+										"value": "0d15449b-fb08-4013-8985-20c148b353ab",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/api/v1/organizations?includeInactive=true&limit=100000",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"api",
+										"v1",
+										"organizations"
+									],
+									"query": [
+										{
+											"key": "includeInactive",
+											"value": "true"
+										},
+										{
+											"key": "limit",
+											"value": "100000"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "IAT with null value",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var validJwt = {",
+											"  \"iss\": \"theIssuer\",",
+											"  \"sub\": \"sampleSubject\",",
+											"  \"aud\": \"theAudience\",",
+											"  \"jti\": \"jwt-id-001\",",
+											"  \"scope\": \"organization-reader\",",
+											"  \"iat\": null,",
+											"  \"nbf\": Math.floor(Date.now() / 1000),",
+											"  \"exp\": Math.floor(Date.now() / 1000) + (60 * 60)",
+											"};",
+											"pm.variables.set(\"localJwt\", JSON.stringify(validJwt));",
+											"",
+											"pm.variables.set(\"expectedHttpCode\", 401);"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let expectedCode = pm.variables.get(\"expectedHttpCode\");",
+											"",
+											"pm.test(\"Status code is \" + expectedCode, function () {",
+											"    pm.response.to.have.status(expectedCode);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"strictSSL": false,
+								"tlsDisabledProtocols": []
+							},
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "payload",
+											"value": "{{localJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "nextCursor",
+										"value": "0d15449b-fb08-4013-8985-20c148b353ab",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/api/v1/organizations?includeInactive=true&limit=100000",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"api",
+										"v1",
+										"organizations"
+									],
+									"query": [
+										{
+											"key": "includeInactive",
+											"value": "true"
+										},
+										{
+											"key": "limit",
+											"value": "100000"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "NBF with null value",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var validJwt = {",
+											"  \"iss\": \"theIssuer\",",
+											"  \"sub\": \"sampleSubject\",",
+											"  \"aud\": \"theAudience\",",
+											"  \"jti\": \"jwt-id-001\",",
+											"  \"scope\": \"organization-reader\",",
+											"  \"iat\": Math.floor(Date.now() / 1000),",
+											"  \"nbf\": null,",
+											"  \"exp\": Math.floor(Date.now() / 1000) + (60 * 60)",
+											"};",
+											"pm.variables.set(\"localJwt\", JSON.stringify(validJwt));",
+											"",
+											"pm.variables.set(\"expectedHttpCode\", 401);"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let expectedCode = pm.variables.get(\"expectedHttpCode\");",
+											"",
+											"pm.test(\"Status code is \" + expectedCode, function () {",
+											"    pm.response.to.have.status(expectedCode);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"strictSSL": false,
+								"tlsDisabledProtocols": []
+							},
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "payload",
+											"value": "{{localJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "nextCursor",
+										"value": "0d15449b-fb08-4013-8985-20c148b353ab",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/api/v1/organizations?includeInactive=true&limit=100000",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"api",
+										"v1",
+										"organizations"
+									],
+									"query": [
+										{
+											"key": "includeInactive",
+											"value": "true"
+										},
+										{
+											"key": "limit",
+											"value": "100000"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "EXP with null value",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var validJwt = {",
+											"  \"iss\": \"theIssuer\",",
+											"  \"sub\": \"sampleSubject\",",
+											"  \"aud\": \"theAudience\",",
+											"  \"jti\": \"jwt-id-001\",",
+											"  \"scope\": \"organization-reader\",",
+											"  \"iat\": Math.floor(Date.now() / 1000),",
+											"  \"nbf\": Math.floor(Date.now() / 1000),",
+											"  \"exp\": null",
+											"};",
+											"pm.variables.set(\"localJwt\", JSON.stringify(validJwt));",
+											"",
+											"pm.variables.set(\"expectedHttpCode\", 401);"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let expectedCode = pm.variables.get(\"expectedHttpCode\");",
+											"",
+											"pm.test(\"Status code is \" + expectedCode, function () {",
+											"    pm.response.to.have.status(expectedCode);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"strictSSL": false,
+								"tlsDisabledProtocols": []
+							},
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "payload",
+											"value": "{{localJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "nextCursor",
+										"value": "0d15449b-fb08-4013-8985-20c148b353ab",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/api/v1/organizations?includeInactive=true&limit=100000",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"api",
+										"v1",
+										"organizations"
+									],
+									"query": [
+										{
+											"key": "includeInactive",
+											"value": "true"
+										},
+										{
+											"key": "limit",
+											"value": "100000"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "IAT & NBF mismatch",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var validJwt = {",
+											"  \"iss\": \"theIssuer\",",
+											"  \"sub\": \"sampleSubject\",",
+											"  \"aud\": \"theAudience\",",
+											"  \"jti\": \"jwt-id-001\",",
+											"  \"scope\": \"organization-reader\",",
+											"  \"iat\": Math.floor(Date.now() / 1000) - (30 * 60),",
+											"  \"nbf\": Math.floor(Date.now() / 1000),",
+											"  \"exp\": Math.floor(Date.now() / 1000) + (60 * 60)",
+											"};",
+											"pm.variables.set(\"localJwt\", JSON.stringify(validJwt));",
+											"",
+											"pm.variables.set(\"expectedHttpCode\", 200);"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let expectedCode = pm.variables.get(\"expectedHttpCode\");",
+											"",
+											"pm.test(\"Status code is \" + expectedCode, function () {",
+											"    pm.response.to.have.status(expectedCode);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"strictSSL": false,
+								"tlsDisabledProtocols": []
+							},
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "payload",
+											"value": "{{localJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "nextCursor",
+										"value": "0d15449b-fb08-4013-8985-20c148b353ab",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/api/v1/organizations?includeInactive=true&limit=100000",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"api",
+										"v1",
+										"organizations"
+									],
+									"query": [
+										{
+											"key": "includeInactive",
+											"value": "true"
+										},
+										{
+											"key": "limit",
+											"value": "100000"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Borderline EXP",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var validJwt = {",
+											"  \"iss\": \"theIssuer\",",
+											"  \"sub\": \"sampleSubject\",",
+											"  \"aud\": \"theAudience\",",
+											"  \"jti\": \"jwt-id-001\",",
+											"  \"scope\": \"organization-reader\",",
+											"  \"iat\": Math.floor(Date.now() / 1000),",
+											"  \"nbf\": Math.floor(Date.now() / 1000),",
+											"  \"exp\": Math.floor(Date.now() / 1000) + (1 * 60)",
+											"};",
+											"pm.variables.set(\"localJwt\", JSON.stringify(validJwt));",
+											"",
+											"pm.variables.set(\"expectedHttpCode\", 200);"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let expectedCode = pm.variables.get(\"expectedHttpCode\");",
+											"",
+											"pm.test(\"Status code is \" + expectedCode, function () {",
+											"    pm.response.to.have.status(expectedCode);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"strictSSL": false,
+								"tlsDisabledProtocols": []
+							},
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "payload",
+											"value": "{{localJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "nextCursor",
+										"value": "0d15449b-fb08-4013-8985-20c148b353ab",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/api/v1/organizations?includeInactive=true&limit=100000",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"api",
+										"v1",
+										"organizations"
+									],
+									"query": [
+										{
+											"key": "includeInactive",
+											"value": "true"
+										},
+										{
+											"key": "limit",
+											"value": "100000"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Clock drift test",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var validJwt = {",
+											"  \"iss\": \"theIssuer\",",
+											"  \"sub\": \"sampleSubject\",",
+											"  \"aud\": \"theAudience\",",
+											"  \"jti\": \"jwt-id-001\",",
+											"  \"scope\": \"organization-reader\",",
+											"  \"iat\": Math.floor(Date.now() / 1000) - (55 * 60),",
+											"  \"exp\": Math.floor(Date.now() / 1000) + (5 * 60)",
+											"};",
+											"pm.variables.set(\"localJwt\", JSON.stringify(validJwt));",
+											"",
+											"pm.variables.set(\"expectedHttpCode\", 200);"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let expectedCode = pm.variables.get(\"expectedHttpCode\");",
+											"",
+											"pm.test(\"Status code is \" + expectedCode, function () {",
+											"    pm.response.to.have.status(expectedCode);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"strictSSL": false,
+								"tlsDisabledProtocols": []
+							},
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "payload",
+											"value": "{{localJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "nextCursor",
+										"value": "0d15449b-fb08-4013-8985-20c148b353ab",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/api/v1/organizations?includeInactive=true&limit=100000",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"api",
+										"v1",
+										"organizations"
+									],
+									"query": [
+										{
+											"key": "includeInactive",
+											"value": "true"
+										},
+										{
+											"key": "limit",
+											"value": "100000"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Invalid IAT value - human readable time",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const now = new Date();",
+											"",
+											"var validJwt = {",
+											"  \"iss\": \"theIssuer\",",
+											"  \"sub\": \"sampleSubject\",",
+											"  \"aud\": \"theAudience\",",
+											"  \"jti\": \"jwt-id-001\",",
+											"  \"scope\": \"organization-reader\",",
+											"  \"iat\": now.toLocaleString(),",
+											"  \"nbf\": Math.floor(Date.now() / 1000),",
+											"  \"exp\": Math.floor(Date.now() / 1000) + (60 * 60)",
+											"};",
+											"pm.variables.set(\"localJwt\", JSON.stringify(validJwt));",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 401\", function () {",
+											"    pm.response.to.have.status(401);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"strictSSL": false,
+								"tlsDisabledProtocols": []
+							},
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "payload",
+											"value": "{{localJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "nextCursor",
+										"value": "0d15449b-fb08-4013-8985-20c148b353ab",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/api/v1/organizations?includeInactive=true&limit=100000",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"api",
+										"v1",
+										"organizations"
+									],
+									"query": [
+										{
+											"key": "includeInactive",
+											"value": "true"
+										},
+										{
+											"key": "limit",
+											"value": "100000"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Invalid NBF value - human readable time",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const now = new Date();",
+											"",
+											"var validJwt = {",
+											"  \"iss\": \"theIssuer\",",
+											"  \"sub\": \"sampleSubject\",",
+											"  \"aud\": \"theAudience\",",
+											"  \"jti\": \"jwt-id-001\",",
+											"  \"scope\": \"organization-reader\",",
+											"  \"iat\": Math.floor(Date.now() / 1000),",
+											"  \"nbf\": now.toLocaleString(),",
+											"  \"exp\": Math.floor(Date.now() / 1000) + (60 * 60)",
+											"};",
+											"pm.variables.set(\"localJwt\", JSON.stringify(validJwt));",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 401\", function () {",
+											"    pm.response.to.have.status(401);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"strictSSL": false,
+								"tlsDisabledProtocols": []
+							},
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "payload",
+											"value": "{{localJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "nextCursor",
+										"value": "0d15449b-fb08-4013-8985-20c148b353ab",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/api/v1/organizations?includeInactive=true&limit=100000",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"api",
+										"v1",
+										"organizations"
+									],
+									"query": [
+										{
+											"key": "includeInactive",
+											"value": "true"
+										},
+										{
+											"key": "limit",
+											"value": "100000"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Invalid EXP value - human readable time",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const now = new Date();",
+											"now.setTime(now.getTime() + 60000);",
+											"",
+											"var validJwt = {",
+											"  \"iss\": \"theIssuer\",",
+											"  \"sub\": \"sampleSubject\",",
+											"  \"aud\": \"theAudience\",",
+											"  \"jti\": \"jwt-id-001\",",
+											"  \"scope\": \"organization-reader\",",
+											"  \"iat\": Math.floor(Date.now() / 1000),",
+											"  \"nbf\": Math.floor(Date.now() / 1000),",
+											"  \"exp\": now.toLocaleString()",
+											"};",
+											"pm.variables.set(\"localJwt\", JSON.stringify(validJwt));",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 401\", function () {",
+											"    pm.response.to.have.status(401);",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"strictSSL": false,
+								"tlsDisabledProtocols": []
+							},
+							"request": {
+								"auth": {
+									"type": "jwt",
+									"jwt": [
+										{
+											"key": "secret",
+											"value": "{{jwtSharedSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "isSecretBase64Encoded",
+											"value": false,
+											"type": "boolean"
+										},
+										{
+											"key": "payload",
+											"value": "{{localJwt}}",
+											"type": "string"
+										},
+										{
+											"key": "addTokenTo",
+											"value": "header",
+											"type": "string"
+										},
+										{
+											"key": "algorithm",
+											"value": "HS256",
+											"type": "string"
+										},
+										{
+											"key": "headerPrefix",
+											"value": "Bearer",
+											"type": "string"
+										},
+										{
+											"key": "queryParamKey",
+											"value": "token",
+											"type": "string"
+										},
+										{
+											"key": "header",
+											"value": "{}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "nextCursor",
+										"value": "0d15449b-fb08-4013-8985-20c148b353ab",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/api/v1/organizations?includeInactive=true&limit=100000",
+									"protocol": "{{no_cert_protocol}}",
+									"host": [
+										"{{no_cert_host}}"
+									],
+									"port": "{{no_cert_port}}",
+									"path": [
+										"api",
+										"v1",
+										"organizations"
+									],
+									"query": [
+										{
+											"key": "includeInactive",
+											"value": "true"
+										},
+										{
+											"key": "limit",
+											"value": "100000"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
 		}
 	],
 	"event": [
@@ -22492,16 +24844,20 @@
 					"pm.collectionVariables.set(\"GoodMessageVXULF\", goodRequestVXU.replace(\"\\r\", \"\\n\"))",
 					"pm.collectionVariables.set(\"GoodMessageVXUCRLF\", goodRequestVXU.replace(\"\\r\", \"\\r\\n\"))",
 					"",
+					"// checkOrganizationOverride requires admin role in order to use x-xform-organization",
 					"var validJwt = {",
 					"  \"iss\": \"theIssuer\",",
 					"  \"sub\": \"sampleSubject\",",
 					"  \"aud\": \"theAudience\",",
 					"  \"jti\": \"jwt-id-001\",",
-					"  \"scope\": \"scope1 pipeline-reader admin\",",
+					"  \"iat\": Math.floor(Date.now() / 1000),",
+					"  \"nbf\": Math.floor(Date.now() / 1000),",
+					"  \"exp\": Math.floor(Date.now() / 1000) + (60 * 60),",
+					"  \"scope\": \"\",",
 					"  \"groups\": [",
-					"    \"BusinessAnalyst\",",
-					"    \"Admin\",",
-					"    \"Group3\"",
+					"    \"Xform Sender\",",
+					"    \"Xform Business Analyst\",",
+					"    \"Xform Admin\"",
 					"  ]",
 					"};",
 					"pm.collectionVariables.set(\"validJwt\", JSON.stringify(validJwt));",
@@ -22511,6 +24867,9 @@
 					"  \"sub\": \"sampleSubject\",",
 					"  \"aud\": \"theAudience\",",
 					"  \"jti\": \"jwt-id-001\",",
+					"  \"iat\": Math.floor(Date.now() / 1000),",
+					"  \"nbf\": Math.floor(Date.now() / 1000),",
+					"  \"exp\": Math.floor(Date.now() / 1000) + (60 * 60),",
 					"  \"scope\": \"\",",
 					"  \"groups\": []",
 					"};",
@@ -23738,6 +26097,18 @@
 			"value": ""
 		},
 		{
+			"key": "fhirPatientGiven",
+			"value": ""
+		},
+		{
+			"key": "fhirPatientFamily",
+			"value": ""
+		},
+		{
+			"key": "fhirPatientDOB",
+			"value": ""
+		},
+		{
 			"key": "TooLargeMessage",
 			"value": ""
 		},
@@ -23751,18 +26122,6 @@
 		},
 		{
 			"key": "hex1b",
-			"value": ""
-		},
-		{
-			"key": "fhirPatientGiven",
-			"value": ""
-		},
-		{
-			"key": "fhirPatientFamily",
-			"value": ""
-		},
-		{
-			"key": "fhirPatientDOB",
 			"value": ""
 		}
 	]


### PR DESCRIPTION
**NOTE:** This should not be merged to develop until izgw-core 2.1.8 release has been cut.  Requires 2.1.8 izgw-core.  Until that release is cut,  to run locally you will need to pull down 2.1.7 izgw-core locally and mvn install build to put into your local repository.

Changes:

* Update pom.xml to point to izgw-core 2.1.8, which contains updates to JWT validation
* Add new jwt settings to application.yml.  These are specific to 2.1.8 izgw-core update
* Update group-role-mapping.json to include groups we are setting up as standard in Okta
* Add JWT validation tests to Postman