### PR TITLE
IGDD-2043 - Add logging for available Operations & Preconditions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>gov.cdc.izgateway</groupId>
 	<artifactId>xform</artifactId>
-        <version>0.8.0</version>
+        <version>0.9.0</version>
 	<name>xform</name>
 	<description>IZ Gateway Xform Service</description>
 	<properties>

--- a/src/main/java/gov/cdc/izgateway/xform/services/OperationService.java
+++ b/src/main/java/gov/cdc/izgateway/xform/services/OperationService.java
@@ -2,6 +2,7 @@ package gov.cdc.izgateway.xform.services;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
+import gov.cdc.izgateway.xform.logging.ApiEventLogger;
 import gov.cdc.izgateway.xform.model.OperationInfo;
 import gov.cdc.izgateway.xform.model.OperationInfoProperty;
 import gov.cdc.izgateway.xform.operations.Operation;
@@ -44,6 +45,7 @@ public class OperationService implements XformService<OperationInfo> {
                 operationInfoList.add(info);
             }
         }
+        ApiEventLogger.logReadEvent(operationInfoList);
         return operationInfoList;
     }
 

--- a/src/main/java/gov/cdc/izgateway/xform/services/PreconditionService.java
+++ b/src/main/java/gov/cdc/izgateway/xform/services/PreconditionService.java
@@ -2,6 +2,7 @@ package gov.cdc.izgateway.xform.services;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
+import gov.cdc.izgateway.xform.logging.ApiEventLogger;
 import gov.cdc.izgateway.xform.model.PreconditionInfo;
 import gov.cdc.izgateway.xform.model.PreconditionInfoProperty;
 import gov.cdc.izgateway.xform.preconditions.Precondition;
@@ -45,6 +46,8 @@ public class PreconditionService implements XformService<PreconditionInfo> {
                 preconditionInfoList.add(info);
             }
         }
+
+        ApiEventLogger.logReadEvent(preconditionInfoList);
         return preconditionInfoList;
     }
 

--- a/testing/scripts/TS_Integration_Test.postman_collection.json
+++ b/testing/scripts/TS_Integration_Test.postman_collection.json
@@ -4155,10 +4155,7 @@
 															"    pm.expect(response.length).to.equal(expectedMethods.length);",
 															"});",
 															"",
-															"// Commenting out for now, calls to get list of Operations",
-															"// is not currently logging in Xform Service. A ticket has been entered",
-															"// into backlog with reminder to uncomment this.",
-															"//utils.testForApiLog(pm, 'READ');",
+															"utils.testForApiLog(pm, 'READ');",
 															""
 														],
 														"type": "text/javascript",
@@ -8089,10 +8086,7 @@
 															"    pm.expect(response.length).to.equal(expectedMethods.length);",
 															"});",
 															"",
-															"// Commenting out for now, calls to get list of Preconditions",
-															"// is not currently logging in Xform Service. A ticket has been entered",
-															"// into backlog with reminder to uncomment this.",
-															"//utils.testForApiLog(pm, 'READ');"
+															"utils.testForApiLog(pm, 'READ');"
 														],
 														"type": "text/javascript",
 														"packages": {}
@@ -17909,10 +17903,7 @@
 															"    pm.expect(response.length).to.equal(expectedMethods.length);",
 															"});",
 															"",
-															"// Commenting out for now, calls to get list of Operations",
-															"// is not currently logging in Xform Service. A ticket has been entered",
-															"// into backlog with reminder to uncomment this.",
-															"//utils.testForApiLog(pm, 'READ');",
+															"utils.testForApiLog(pm, 'READ');",
 															"",
 															""
 														],
@@ -21953,7 +21944,9 @@
 															"// Test to ensure no extra methods are present",
 															"pm.test(\"No extra methods present\", function() {",
 															"    pm.expect(response.length).to.equal(expectedMethods.length);",
-															"});"
+															"});",
+															"",
+															"utils.testForApiLog(pm, 'READ');"
 														],
 														"type": "text/javascript",
 														"packages": {}


### PR DESCRIPTION
Added lines to log the READ in the OperationService and PreconditionService. Explored ways to implement these similar to other entities in the system (via repository) but things were getting messy as the Operation and Preconditions are determined via reflection. Happy to entertain feedback there.

Bumped version of Xform Service to 0.9.0 for the next release cycle.

Added calls into Postman test suite to validate that a READ log entry exists when calls are made to the API to get Operations and Preconditions.