### PR TITLE
IGDD-2016 Adding code to make Organization class organizationAware

### DIFF
--- a/src/main/java/gov/cdc/izgateway/xform/model/Organization.java
+++ b/src/main/java/gov/cdc/izgateway/xform/model/Organization.java
@@ -1,5 +1,6 @@
 package gov.cdc.izgateway.xform.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @DynamoDbBean
-public class Organization extends BaseModel {
+public class Organization extends BaseModel implements OrganizationAware {
     @NotBlank(message = "Organization name is required")
     private String organizationName;
 
@@ -21,4 +22,9 @@ public class Organization extends BaseModel {
 
     @NotNull(message = "Organization common name is required")
     private String commonName;
+
+    @JsonIgnore
+    public UUID getOrganizationId() {
+        return id;
+    }
 }

--- a/src/main/java/gov/cdc/izgateway/xform/services/GenericService.java
+++ b/src/main/java/gov/cdc/izgateway/xform/services/GenericService.java
@@ -6,6 +6,7 @@ import gov.cdc.izgateway.xform.logging.ApiEventLogger;
 import gov.cdc.izgateway.xform.model.BaseModel;
 import gov.cdc.izgateway.xform.model.OrganizationAware;
 import gov.cdc.izgateway.xform.repository.XformRepository;
+import gov.cdc.izgateway.xform.security.Roles;
 import gov.cdc.izgateway.xform.security.XformPrincipal;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -26,8 +27,7 @@ public abstract class GenericService<T extends BaseModel> implements XformServic
     public T getObject(UUID id) {
         T existing = repo.getEntity(id);
 
-        // Check if the object's organization ID is in the allowed organization IDs
-        if (existing instanceof OrganizationAware organizationAware && !getAllowedOrganizationIds().contains(organizationAware.getOrganizationId())) {
+        if (!isAccessible(existing)) {
             return null;
         }
 
@@ -39,8 +39,7 @@ public abstract class GenericService<T extends BaseModel> implements XformServic
     @Override
     public List<T> getList() {
         ArrayList<T> list = new ArrayList<>(repo.getEntitySet());
-
-        list.removeIf(item -> item instanceof OrganizationAware organizationAware && !getAllowedOrganizationIds().contains(organizationAware.getOrganizationId()));
+        list.removeIf(item -> !isAccessible(item));
 
         ApiEventLogger.logReadEvent(list);
         return list;
@@ -63,7 +62,7 @@ public abstract class GenericService<T extends BaseModel> implements XformServic
     public void create(T obj) {
 
         // Check if the object's organization ID is in the allowed organization IDs
-        if (obj instanceof OrganizationAware organizationAware && !getAllowedOrganizationIds().contains(organizationAware.getOrganizationId())) {
+        if (!isAccessible(obj)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You do not have permission to create this object");
         }
 
@@ -88,7 +87,7 @@ public abstract class GenericService<T extends BaseModel> implements XformServic
         }
 
         // Check if the organization ID is in the allowed organization IDs
-        if (item instanceof OrganizationAware organizationAware && !getAllowedOrganizationIds().contains(organizationAware.getOrganizationId())) {
+        if (!isAccessible(item)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You do not have permission to delete this object");
         }
 
@@ -107,6 +106,23 @@ public abstract class GenericService<T extends BaseModel> implements XformServic
     		return x.getAllowedOrganizationIds();
     	}
     	return Collections.emptySet();
+    }
+
+    /**
+     * Check if the object is accessible based on its organization ID or if the user is an admin.
+     */
+    private boolean isAccessible(T obj) {
+        // If the RequestContext principal is an admin, return true
+        if (RequestContext.getPrincipal().getRoles().contains(Roles.ADMIN))  {
+            return true;
+        }
+
+        if (obj instanceof OrganizationAware organizationAware) {
+            Set<UUID> allowedOrgIds = getAllowedOrganizationIds();
+            return allowedOrgIds.contains(organizationAware.getOrganizationId());
+        }
+
+        return true; // If the object is not organization-aware, it's accessible
     }
 
     /**

--- a/src/main/java/gov/cdc/izgateway/xform/services/XformPrincipalService.java
+++ b/src/main/java/gov/cdc/izgateway/xform/services/XformPrincipalService.java
@@ -69,6 +69,12 @@ public class XformPrincipalService implements PrincipalService {
             XformPrincipal xformPrincipal = new XformPrincipal(izgPrincipal);
             User user = userService.getUserByUserName(xformPrincipal.getName());
             xformPrincipal.setAllowedOrganizationIds(user.getOrganizationIds());
+
+            // Remove admin role if X-Not-Admin header is present (used for testing)
+            if (!StringUtils.isEmpty(request.getHeader(Roles.NOT_ADMIN_HEADER))) {
+                xformPrincipal.getRoles().remove(Roles.ADMIN);
+            }
+
             return xformPrincipal;
         }
     }

--- a/testing/scripts/TS_Integration_Test.postman_collection.json
+++ b/testing/scripts/TS_Integration_Test.postman_collection.json
@@ -1,10 +1,9 @@
 {
 	"info": {
-		"_postman_id": "4da6ec63-7df5-4784-91c7-fa43f2447bbc",
+		"_postman_id": "339a1b15-9a84-4988-b75b-a5c3921bd553",
 		"name": "TS Integration Test",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "2729094",
-		"_collection_link": "https://lively-space-957471.postman.co/workspace/IZG~107100cc-f7df-4edf-97fa-f5e0022afeca/collection/2729094-4da6ec63-7df5-4784-91c7-fa43f2447bbc?action=share&source=collection_link&creator=2729094"
+		"_exporter_id": "28864196"
 	},
 	"item": [
 		{
@@ -5884,6 +5883,133 @@
 												"v1",
 												"organizations",
 												"{{id2}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get Organizations - Admin role",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"returns 200 OK code\", function() {",
+													"    pm.expect(pm.response.code).to.equal(200);",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"",
+													"// Setting the count for admin role to compare in the next test for non-admin role",
+													"pm.collectionVariables.set(\"organizationCountForAdminRole\", response[\"data\"].length);",
+													"",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{protocol}}://{{host}}:{{port}}/api/v1/organizations?limit=100000",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}",
+											"path": [
+												"api",
+												"v1",
+												"organizations"
+											],
+											"query": [
+												{
+													"key": "limit",
+													"value": "100000"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Get Organizations - Not admin role",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"returns 200 OK code\", function() {",
+													"    pm.expect(pm.response.code).to.equal(200);",
+													"});",
+													"",
+													"let response = pm.response.json();",
+													"let organizationCountForNonAdminRole = 0;",
+													"",
+													"organizationCountForNonAdminRole = response[\"data\"].length;",
+													"",
+													"pm.test(\"Organization count for non-admin is less than count for admin\", function() {",
+													"    let organizationCountForAdminRole = pm.collectionVariables.get(\"organizationCountForAdminRole\");",
+													"",
+													"    pm.expect(organizationCountForNonAdminRole).to.be.lessThan(organizationCountForAdminRole);",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "X-Not-Admin",
+												"value": "true",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{protocol}}://{{host}}:{{port}}/api/v1/organizations?limit=100000",
+											"protocol": "{{protocol}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}",
+											"path": [
+												"api",
+												"v1",
+												"organizations"
+											],
+											"query": [
+												{
+													"key": "limit",
+													"value": "100000"
+												}
 											]
 										}
 									},
@@ -28708,43 +28834,7 @@
 			"value": ""
 		},
 		{
-			"key": "currentOrgId",
-			"value": ""
-		},
-		{
-			"key": "currentOrgActive",
-			"value": ""
-		},
-		{
-			"key": "currentName",
-			"value": ""
-		},
-		{
-			"key": "currentOrganizationId",
-			"value": ""
-		},
-		{
-			"key": "currentInboundEndpoint",
-			"value": ""
-		},
-		{
-			"key": "currentOutboundEndpoint",
-			"value": ""
-		},
-		{
-			"key": "currentActive",
-			"value": ""
-		},
-		{
-			"key": "createdPipeline",
-			"value": ""
-		},
-		{
-			"key": "currentId",
-			"value": ""
-		},
-		{
-			"key": "nonExistingId",
+			"key": "organizationCountForAdminRole",
 			"value": ""
 		}
 	]


### PR DESCRIPTION
Adding code to make Organization organizationAware.  Includes logic to remove admin role if X-Not-Admin header is present (used for postman testing).  Postman tests have been updated.  

Needed to add JsonIgnore to the new organizationId field as it broke other tests and because it does not need to be marshalled. It is simply a helper function to access the organization's id through the getOrganizationId method.