### PR TITLE
IGDD-2092 Bumping spring boot version to 3.4.7 to address tomcat CVE.  

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,10 @@
 					<groupId>com.mysql</groupId>
 					<artifactId>mysql-connector-j</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>commons-fileupload</groupId>
+					<artifactId>commons-fileupload</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.6</version>
+		<version>3.4.7</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>gov.cdc.izgateway</groupId>


### PR DESCRIPTION
This will upgrade Tomcat to 10.1.42.

Definition of Done
- [x] CI/CD Is passing
- [x] There is either a Unit or Integration Test in CI/CD (n/a update to spring library in pom no new code)
- [x] Acceptance Criteria is Met
- [x] Code adheres to Team Coding Standards
- [x] No Major Code Smells
- [x] No Security Findings (check image in ECR, and Dependency Check Report in CD/CD)
- [x] Release Notes are updated noting the fix 