### PR TITLE
Update aws ecs update in GitHub Action to remove old NLB related cluster and service.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -193,7 +193,6 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: transformation-service
         run: |
-          aws ecs update-service --cluster xform-service-dev --service xform-service-dev --force-new-deployment --enable-execute-command --desired-count 1 | jq ".service.deployments[].id"
           aws ecs update-service --cluster xform-service-alb-dev --service xform-service-alb-dev --force-new-deployment --enable-execute-command --desired-count 2 | jq ".service.deployments[].id"
           aws ecs wait services-stable --cluster xform-service-alb-dev --service xform-service-alb-dev
 

--- a/testing/scripts/dev.xform.izgateway.org.postman_environment.json
+++ b/testing/scripts/dev.xform.izgateway.org.postman_environment.json
@@ -4,7 +4,7 @@
 	"values": [
 		{
 			"key": "host",
-			"value": "dev.alb.xform.izgateway.org",
+			"value": "dev.xform.izgateway.org",
 			"enabled": true
 		},
 		{


### PR DESCRIPTION
Update dns name in postman environment used by GitHub Action to point to dev.xform.izgateway.org instead of dev.alb.izgateway.org