### PR TITLE
IGDD-2157 - Update GitHub Action to deploy in multiple regions.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,8 +1,5 @@
 name: Java CI with Maven
 
-env:
-  AWS_REGIONS: "us-east-1 us-west-2"
-
 on:
   pull_request:
     branches:
@@ -196,7 +193,16 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: transformation-service
         run: |
-          # Start deployments in all configured regions
+          # AWS_REGIONS can be set in GitHub Settings → Secrets and variables → Actions
+          # Format: space-separated regions (e.g., "us-east-1 us-west-2")
+
+          # Set default region if AWS_REGIONS isn't configured
+          if [ -z "$AWS_REGIONS" ]; then
+            echo "AWS_REGIONS not set, defaulting to us-east-1"
+            AWS_REGIONS="us-east-1"
+          fi
+          
+          # Start deployments in all regions configured via AWS_REGIONS environment variable
           for region in $AWS_REGIONS; do
             echo "Update ECS services in $region"
             aws ecs update-service --region $region --cluster xform-service-alb-dev --service xform-service-alb-dev --force-new-deployment --enable-execute-command --desired-count 2 | jq ".service.deployments[].id" &
@@ -205,7 +211,7 @@ jobs:
           wait
           
           for region in $AWS_REGIONS; do
-            echo "Wait for ECS servicestability in $region"
+            echo "Wait for ECS service stability in $region"
             aws ecs wait services-stable --region $region --cluster xform-service-alb-dev --service xform-service-alb-dev &
           done
           

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -188,10 +188,10 @@ jobs:
           docker image tag izgw-transform:${{env.IMAGE_TAG}} $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker image push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
 
-        # AWS_REGIONS can be set in GitHub Settings → Secrets and variables → Actions
+        # AWS_REGIONS can be set in GitHub Settings -> Secrets and variables -> Actions -> Variables -> Repository Variables
         # Format: space-separated regions (e.g., "us-east-1 us-west-2")
         # Default of us-east-1 will be used if this is not set
-        # ECS_DESIRED_COUNT can be set in GitHub Settings -> Secrets and variables -> Actions
+        # ECS_DESIRED_COUNT can be set in GitHub Settings -> Secrets and variables -> Actions -> Variables -> Repository Variables
         # This is used to know how many container instances to start. Default is 1 if not set
       - name: Update ECS service to force new deployment of latest image
         env:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,5 +1,8 @@
 name: Java CI with Maven
 
+env:
+  AWS_REGIONS: "us-east-1 us-west-2"
+
 on:
   pull_request:
     branches:
@@ -193,8 +196,20 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: transformation-service
         run: |
-          aws ecs update-service --cluster xform-service-alb-dev --service xform-service-alb-dev --force-new-deployment --enable-execute-command --desired-count 2 | jq ".service.deployments[].id"
-          aws ecs wait services-stable --cluster xform-service-alb-dev --service xform-service-alb-dev
+          # Start deployments in all configured regions
+          for region in $AWS_REGIONS; do
+            echo "Update ECS services in $region"
+            aws ecs update-service --region $region --cluster xform-service-alb-dev --service xform-service-alb-dev --force-new-deployment --enable-execute-command --desired-count 2 | jq ".service.deployments[].id" &
+          done
+          
+          wait
+          
+          for region in $AWS_REGIONS; do
+            echo "Wait for ECS servicestability in $region"
+            aws ecs wait services-stable --region $region --cluster xform-service-alb-dev --service xform-service-alb-dev &
+          done
+          
+          wait
 
       - name: Setup certs
         env:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -211,7 +211,7 @@ jobs:
           fi
           
           for region in $AWS_REGIONS; do
-            echo "Update ECS services in $region"
+            echo "Update ECS services in $region (starting $ECS_DESIRED_COUNT containers)"
             aws ecs update-service --region $region --cluster xform-service-alb-dev --service xform-service-alb-dev --force-new-deployment --enable-execute-command --desired-count $ECS_DESIRED_COUNT | jq ".service.deployments[].id" &
           done
           

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -191,6 +191,8 @@ jobs:
         # AWS_REGIONS can be set in GitHub Settings → Secrets and variables → Actions
         # Format: space-separated regions (e.g., "us-east-1 us-west-2")
         # Default of us-east-1 will be used if this is not set
+        # ECS_DESIRED_COUNT can be set in GitHub Settings -> Secrets and variables -> Actions
+        # This is used to know how many container instances to start. Default is 1 if not set
       - name: Update ECS service to force new deployment of latest image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -201,9 +203,14 @@ jobs:
             AWS_REGIONS="us-east-1"
           fi
           
+          if [ -z "$ECS_DESIRED_COUNT" ]; then
+            echo "ECS_DESIRED_COUNT not set, defaulting to 1"
+            ECS_DESIRED_COUNT="1"
+          fi
+          
           for region in $AWS_REGIONS; do
             echo "Update ECS services in $region"
-            aws ecs update-service --region $region --cluster xform-service-alb-dev --service xform-service-alb-dev --force-new-deployment --enable-execute-command --desired-count 2 | jq ".service.deployments[].id" &
+            aws ecs update-service --region $region --cluster xform-service-alb-dev --service xform-service-alb-dev --force-new-deployment --enable-execute-command --desired-count $ECS_DESIRED_COUNT | jq ".service.deployments[].id" &
           done
           
           wait

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -188,21 +188,19 @@ jobs:
           docker image tag izgw-transform:${{env.IMAGE_TAG}} $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker image push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
 
+        # AWS_REGIONS can be set in GitHub Settings → Secrets and variables → Actions
+        # Format: space-separated regions (e.g., "us-east-1 us-west-2")
+        # Default of us-east-1 will be used if this is not set
       - name: Update ECS service to force new deployment of latest image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: transformation-service
         run: |
-          # AWS_REGIONS can be set in GitHub Settings → Secrets and variables → Actions
-          # Format: space-separated regions (e.g., "us-east-1 us-west-2")
-
-          # Set default region if AWS_REGIONS isn't configured
           if [ -z "$AWS_REGIONS" ]; then
             echo "AWS_REGIONS not set, defaulting to us-east-1"
             AWS_REGIONS="us-east-1"
           fi
           
-          # Start deployments in all regions configured via AWS_REGIONS environment variable
           for region in $AWS_REGIONS; do
             echo "Update ECS services in $region"
             aws ecs update-service --region $region --cluster xform-service-alb-dev --service xform-service-alb-dev --force-new-deployment --enable-execute-command --desired-count 2 | jq ".service.deployments[].id" &

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -197,6 +197,8 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: transformation-service
+          AWS_REGIONS: ${{ vars.AWS_REGIONS }}
+          ECS_DESIRED_COUNT: ${{ vars.ECS_DESIRED_COUNT }}
         run: |
           if [ -z "$AWS_REGIONS" ]; then
             echo "AWS_REGIONS not set, defaulting to us-east-1"


### PR DESCRIPTION
This updates the Github Action to provide ability to deploy updated images into all configured environments.

The AWS environments that will be deployed to can be configured via GitHub Settings -> Secrets and variables -> Actions -> Variables -> Repository Variables in the AWS_REGIONS variable. If that is not set the action will only deploy to us-east-1 by default.  You set multiple regions by separating them by a space.

Also introduced a variable ECS_DESIRED_COUNT which tells the Action how many containers to start.  If this is not set the default is 1.  So if you have AWS_REGIONS set to us-east-1 and us-east-2, but do not set ECS_DESIRED_COUNT then 1 container will be started in each.

This allows us to change things without needing to change this file and do a PR.  For instance, for costs, we may only want to run in 1 region for a while.  So we can change AWS_REGIONS to only have one region.