### PR TITLE
IGDD-2181 IGDD-2184 - Update APHL ECR location and image name, netty update

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -304,7 +304,7 @@ jobs:
           ECR_REGISTRY: ${{ secrets.APHL_ECR_REGISTRY }}
           ECR_REPOSITORY: ${{ secrets.APHL_ECR_REPOSITORY }}
         run: |
-          docker image tag izgw-transform:${{env.IMAGE_TAG}} $ECR_REGISTRY/$ECR_REPOSITORY:izgw-transf-${{env.VERSION}}_${{github.run_number}}
+          docker image tag izgw-transform:${{env.IMAGE_TAG}} $ECR_REGISTRY/$ECR_REPOSITORY:izgw-transf-${{env.VERSION}}-${{github.run_number}}
           docker image push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
      
       - name: List .m2 directory on build failure

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -304,8 +304,7 @@ jobs:
           ECR_REGISTRY: ${{ secrets.APHL_ECR_REGISTRY }}
           ECR_REPOSITORY: ${{ secrets.APHL_ECR_REPOSITORY }}
         run: |
-          docker image tag izgw-transform:${{env.IMAGE_TAG}} $ECR_REGISTRY/$ECR_REPOSITORY:izgw-transform_${{env.IMAGE_TAG}}
-          docker image tag izgw-transform:${{env.IMAGE_TAG}} $ECR_REGISTRY/$ECR_REPOSITORY:izgw-transform_${{env.IMAGE_BRANCH_TAG}}
+          docker image tag izgw-transform:${{env.IMAGE_TAG}} $ECR_REGISTRY/$ECR_REPOSITORY:izgw-transf-${{env.VERSION}}_${{github.run_number}}
           docker image push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
      
       - name: List .m2 directory on build failure

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
 		<commons-lang3.version>3.18.0</commons-lang3.version>
 		<xform.testing.common.pass>XFORM_TESTING_COMMON_PASS</xform.testing.common.pass>
         <tomcat.version>10.1.44</tomcat.version>
+        <spring-framework.version>6.2.10</spring-framework.version>
 	</properties>
 	<repositories>
 		<repository>
@@ -186,7 +187,7 @@
 			<groupId>org.bouncycastle</groupId>
 			<!-- add -debug to get debug jars -->
 			<artifactId>bc-fips</artifactId>
-			<version>2.1.0</version>
+			<version>2.1.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
@@ -468,13 +469,6 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
                 <version>4.2.4.Final</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-framework-bom</artifactId>
-                <version>6.2.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -463,6 +463,20 @@
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>10.4.1</version>
             </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.2.4.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-framework-bom</artifactId>
+                <version>6.2.10</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
 		</dependencies>
 	</dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
 		<camel.version>4.13.0</camel.version>
 		<commons-lang3.version>3.18.0</commons-lang3.version>
 		<xform.testing.common.pass>XFORM_TESTING_COMMON_PASS</xform.testing.common.pass>
+        <tomcat.version>10.1.44</tomcat.version>
 	</properties>
 	<repositories>
 		<repository>


### PR DESCRIPTION
**IGDD-2181**

Update name of image pushed to APHL when release is cut, per request. Also only push one tag, per request. 

GitHub Organization Secrets have been updated

- APHL_ECR_REGISTRY = 273687833332.dkr.ecr.us-west-1.amazonaws.com/izgateway-ha
- APHL_ECR_REPOSITORY = ecr-repo
- APHL_AWS_ACCESS_KEY_ID = you can find value in AWS secrets
- APHL_AWS_SECRET_ACCESS_KEY = you can find value in AWS secrets

This will result in an image being pushed to APHL which look like:

```273687833332.dkr.ecr.us-west-1.amazonaws.com/izgateway-ha/ecr-repo:izgw-transf-0.10.0-1234```

Existing setup pushing to our AWS and GitHub push a "latest" tag.  Also the images pushed to _our_ repos do not include the name as each "component" has their own ECR.  Where as in APHL all components are pushed to the same ECR and therefore need a name.

So, for example, the push to our ECR will look like

```
357442695278.dkr.ecr.us-east-1.amazonaws.com/transformation-service:0.10.0-1234
357442695278.dkr.ecr.us-east-1.amazonaws.com/transformation-service:0.10.0
357442695278.dkr.ecr.us-east-1.amazonaws.com/transformation-service:latest
```

Our push to GitHub is the same.

**IGDD-2184**

Dependency updates, netty, tomcat, bc-fips.