### PR TITLE
Dependency updates for owasp scanner findings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.5</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>gov.cdc.izgateway</groupId>
@@ -26,7 +26,8 @@
 		<commons-lang3.version>3.18.0</commons-lang3.version>
 		<xform.testing.common.pass>XFORM_TESTING_COMMON_PASS</xform.testing.common.pass>
         <tomcat.version>10.1.44</tomcat.version>
-        <spring-framework.version>6.2.10</spring-framework.version>
+        <spring-framework.version>6.2.11</spring-framework.version>
+        <spring-security.version>6.5.4</spring-security.version>
 	</properties>
 	<repositories>
 		<repository>
@@ -468,7 +469,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.2.5.Final</version>
+                <version>4.2.6.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Update spring boot starter parent to 3.5.5 from 3.5.4

Update spring framework version to 6.2.11 from 6.2.10

Update spring security version to 6.5.4

Update netty-bom to 4.2.6.Final from 4.2.5.Final