### PR TITLE
IGDD-2786 - CVE scanner parameter update, suppression update, push to ghcr.io fix

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -179,7 +179,7 @@ jobs:
         # Per https://github.com/marketplace/actions/dependency-check, fix JAVA_HOME location for action
           JAVA_HOME: /opt/jdk
         uses: dependency-check/Dependency-Check_Action@main
-        continue-on-error: true
+        continue-on-error: false
         timeout-minutes: 15
         with:
           project: IZG Transformation Service

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -242,9 +242,16 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Tag and push image to Amazon ECR
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag and push Docker image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: transformation-service
@@ -252,7 +259,11 @@ jobs:
           docker image tag izgw-transform:${{env.IMAGE_TAG}} $ECR_REGISTRY/$ECR_REPOSITORY:${{env.IMAGE_TAG}}
           docker image tag izgw-transform:${{env.IMAGE_TAG}} $ECR_REGISTRY/$ECR_REPOSITORY:${{env.IMAGE_BRANCH_TAG}}
           docker image tag izgw-transform:${{env.IMAGE_TAG}} $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker image tag izgw-transform:${{env.IMAGE_TAG}} ghcr.io/izgateway/izgw-transform:${{env.IMAGE_TAG}}
+          docker image tag izgw-transform:${{env.IMAGE_TAG}} ghcr.io/izgateway/izgw-transform:${{env.IMAGE_BRANCH_TAG}}
+          docker image tag izgw-transform:${{env.IMAGE_TAG}} ghcr.io/izgateway/izgw-transform:latest
           docker image push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
+          docker image push --all-tags ghcr.io/izgateway/izgw-transform
 
         # AWS_REGIONS can be set in GitHub Settings -> Secrets and variables -> Actions -> Variables -> Repository Variables
         # Format: space-separated regions (e.g., "us-east-1 us-west-2")
@@ -335,22 +346,6 @@ jobs:
           name: TestLogs
           path: ./testing/logs
                                       
-      - name: Login to GitHub Repository
-        if: github.ref == 'refs/heads/main'
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Tag, push and deploy image to Github Repository
-        if: github.ref == 'refs/heads/main'
-        run: |
-          docker image tag izgw-transform:${{env.IMAGE_TAG}} ghcr.io/izgateway/izgw-transform:${{env.IMAGE_TAG}}
-          docker image tag izgw-transform:${{env.IMAGE_TAG}} ghcr.io/izgateway/izgw-transform:${{env.IMAGE_BRANCH_TAG}}
-          docker image tag izgw-transform:${{env.IMAGE_TAG}} ghcr.io/izgateway/izgw-transform:latest
-          docker image push --all-tags ghcr.io/izgateway/izgw-transform
-
       - name: Configure AWS credentials for APHL
         if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/Release')) }}
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -179,6 +179,8 @@ jobs:
         # Per https://github.com/marketplace/actions/dependency-check, fix JAVA_HOME location for action
           JAVA_HOME: /opt/jdk
         uses: dependency-check/Dependency-Check_Action@main
+        continue-on-error: true
+        timeout-minutes: 15
         with:
           project: IZG Transformation Service
           path: target/xform-${{env.BASE_TAG}}.jar
@@ -189,9 +191,11 @@ jobs:
             --ossIndexPassword ${{ secrets.OSS_INDEX_PASSWORD }} 
             --failOnCVSS 7
             --suppression ./dependency-suppression.xml
+            --nvdApiKey ${{ secrets.NVDAPIKEY }}
             --disableNuspec    
             --disableNugetconf  
-            --disableAssembly            
+            --disableAssembly   
+            --disableCentral
 
       - name: Upload dependency check log
         uses: actions/upload-artifact@v4

--- a/dependency-suppression.xml
+++ b/dependency-suppression.xml
@@ -59,4 +59,17 @@
         <packageUrl regex="true">^pkg:maven/com\.ibm\.icu/icu4j@.*$</packageUrl>
         <cve>CVE-2025-5222</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        protobuf-java-4.34.1.jar: CVE-2026-0994 is a false positive. The vulnerability is in the Python
+        protobuf library's json_format.ParseDict() function — specifically a recursion-depth counter bug
+        in Python's json_format.py. That code does not exist in the Java implementation. The NVD CPE
+        cpe:/a:google:protobuf is language-agnostic and incorrectly matches the Java artifact.
+        The fix versions cited (5.29.6, 6.33.5) are Python package versions; there is no corresponding
+        Java fix because there is no vulnerability in the Java library.
+        Added: 2026-04-23
+        ]]></notes>
+        <sha1>e3b07cd3be66ec918b9fa4db9863c86d5eeea891</sha1>
+        <cve>CVE-2026-0994</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Updated CVE runner with new parameters to work like izgw-bom and prevent the timeouts.

Added back in ability to push to GitHub Registry