### PR TITLE
Update solution-level logging to include direction and name of solution

### DIFF
--- a/src/main/java/gov/cdc/izgateway/xform/solutions/Solution.java
+++ b/src/main/java/gov/cdc/izgateway/xform/solutions/Solution.java
@@ -27,11 +27,11 @@ public class Solution implements Advisable, Transformable {
         String solutionName = configuration.getSolutionName();
 
         for (gov.cdc.izgateway.xform.model.SolutionOperation so : configuration.getRequestOperations()) {
-            requestOperations.add(new SolutionOperation(so, solutionName, "request"));
+            requestOperations.add(new SolutionOperation(so, solutionName, DataFlowDirection.REQUEST));
         }
 
         for (gov.cdc.izgateway.xform.model.SolutionOperation so : configuration.getResponseOperations()) {
-            responseOperations.add(new SolutionOperation(so, solutionName, "response"));
+            responseOperations.add(new SolutionOperation(so, solutionName, DataFlowDirection.RESPONSE));
         }
     }
 

--- a/src/main/java/gov/cdc/izgateway/xform/solutions/Solution.java
+++ b/src/main/java/gov/cdc/izgateway/xform/solutions/Solution.java
@@ -24,12 +24,14 @@ public class Solution implements Advisable, Transformable {
         requestOperations = new ArrayList<>();
         responseOperations = new ArrayList<>();
 
+        String solutionName = configuration.getSolutionName();
+
         for (gov.cdc.izgateway.xform.model.SolutionOperation so : configuration.getRequestOperations()) {
-            requestOperations.add(new SolutionOperation(so));
+            requestOperations.add(new SolutionOperation(so, solutionName, "request"));
         }
 
         for (gov.cdc.izgateway.xform.model.SolutionOperation so : configuration.getResponseOperations()) {
-            responseOperations.add(new SolutionOperation(so));
+            responseOperations.add(new SolutionOperation(so, solutionName, "response"));
         }
     }
 

--- a/src/main/java/gov/cdc/izgateway/xform/solutions/SolutionOperation.java
+++ b/src/main/java/gov/cdc/izgateway/xform/solutions/SolutionOperation.java
@@ -15,8 +15,12 @@ import java.util.Objects;
 public class SolutionOperation {
     private final List<Precondition> preconditions;
     private final List<Operation> operations;
+    private final String solutionName;
+    private final String direction;
 
-    public SolutionOperation(gov.cdc.izgateway.xform.model.SolutionOperation solutionOperation) {
+    public SolutionOperation(gov.cdc.izgateway.xform.model.SolutionOperation solutionOperation, String solutionName, String direction) {
+        this.solutionName = solutionName;
+        this.direction = direction;
         preconditions = Objects.requireNonNullElse(solutionOperation.getPreconditions(), Collections.emptyList());
         operations = Objects.requireNonNullElse(solutionOperation.getOperationList(), Collections.emptyList());
         // Ensure that SolutionOperation list is sorted by order
@@ -51,7 +55,7 @@ public class SolutionOperation {
     public void execute(ServiceContext context) throws SolutionOperationException {
 
         if (passedPreconditions(context)) {
-            log.debug("Solution-level precondition passed");
+            log.debug("Solution-level precondition passed for {} ({})", solutionName, direction);
             for (Operation op : operations) {
                 try {
                     op.execute(context);
@@ -64,7 +68,7 @@ public class SolutionOperation {
                 }
             }
         } else {
-            log.debug("Solution-level precondition failed");
+            log.debug("Solution-level precondition failed for {} ({})", solutionName, direction);
         }
     }
 }

--- a/src/main/java/gov/cdc/izgateway/xform/solutions/SolutionOperation.java
+++ b/src/main/java/gov/cdc/izgateway/xform/solutions/SolutionOperation.java
@@ -1,6 +1,7 @@
 package gov.cdc.izgateway.xform.solutions;
 
 import gov.cdc.izgateway.xform.context.ServiceContext;
+import gov.cdc.izgateway.xform.enums.DataFlowDirection;
 import gov.cdc.izgateway.xform.exceptions.OperationException;
 import gov.cdc.izgateway.xform.exceptions.SolutionOperationException;
 import gov.cdc.izgateway.xform.operations.Operation;
@@ -16,9 +17,9 @@ public class SolutionOperation {
     private final List<Precondition> preconditions;
     private final List<Operation> operations;
     private final String solutionName;
-    private final String direction;
+    private final DataFlowDirection direction;
 
-    public SolutionOperation(gov.cdc.izgateway.xform.model.SolutionOperation solutionOperation, String solutionName, String direction) {
+    public SolutionOperation(gov.cdc.izgateway.xform.model.SolutionOperation solutionOperation, String solutionName, DataFlowDirection direction) {
         this.solutionName = solutionName;
         this.direction = direction;
         preconditions = Objects.requireNonNullElse(solutionOperation.getPreconditions(), Collections.emptyList());

--- a/src/test/java/gov/cdc/izgateway/xform/operations/SolutionOperationTests.java
+++ b/src/test/java/gov/cdc/izgateway/xform/operations/SolutionOperationTests.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import ca.uhn.hl7v2.HL7Exception;
 import gov.cdc.izgateway.xform.context.ServiceContext;
+import gov.cdc.izgateway.xform.enums.DataFlowDirection;
 import gov.cdc.izgateway.xform.enums.DataType;
 import gov.cdc.izgateway.xform.exceptions.SolutionOperationException;
 import gov.cdc.izgateway.xform.solutions.SolutionOperation;
@@ -41,7 +42,7 @@ PV1|1|I|Ward123^Room456^Bed789|||||||||||||||||1234567890\r""".replace("\n","");
 		// Make a copy of the list when setting it.
 		List<Operation> sortedList = new ArrayList<>(misorderedList);  // First make a copy of misordered list.
 		modelOp.setOperationList(sortedList);
-		SolutionOperation actualOp = new SolutionOperation(modelOp, "TestSolution", "request");
+		SolutionOperation actualOp = new SolutionOperation(modelOp, "TestSolution", DataFlowDirection.REQUEST);
 		// Now sortedList is actually sorted.
 		
 		// Verify the list is no longer misordered.

--- a/src/test/java/gov/cdc/izgateway/xform/operations/SolutionOperationTests.java
+++ b/src/test/java/gov/cdc/izgateway/xform/operations/SolutionOperationTests.java
@@ -41,7 +41,7 @@ PV1|1|I|Ward123^Room456^Bed789|||||||||||||||||1234567890\r""".replace("\n","");
 		// Make a copy of the list when setting it.
 		List<Operation> sortedList = new ArrayList<>(misorderedList);  // First make a copy of misordered list.
 		modelOp.setOperationList(sortedList);
-		SolutionOperation actualOp = new SolutionOperation(modelOp);
+		SolutionOperation actualOp = new SolutionOperation(modelOp, "TestSolution", "request");
 		// Now sortedList is actually sorted.
 		
 		// Verify the list is no longer misordered.


### PR DESCRIPTION
Existing change to solution-level logging shows something like:

```
{
  "@timestamp": "2026-05-04T10:57:38.544771-04:00",
  "@version": "1",
  "message": "Solution-level precondition passed",
  "logger_name": "gov.cdc.izgateway.xform.solutions.SolutionOperation",
  "thread_name": "https-jsse-nio-444-exec-4",
  "level": "DEBUG",
  "level_value": 10000,
  "ipAddress": "0:0:0:0:0:0:0:1",
  "eventId": "1280352333000.3",
  "commonName": "amoody.testing.izgateway.org",
  "sessionId": "F3FF6F5A899196D59907E02A06BDC7DD",
  "requestUri": "/IISHubService",
  "method": "POST"
}
```

This change adds the direction the message is travel in at the time of the solution-level precondition check and the name of the solution. So we end up with something like:

```
{
  "@timestamp": "2026-05-04T11:43:40.549225-04:00",
  "@version": "1",
  "message": "Solution-level precondition passed for Postman Test For State Precondition (REQUEST)",
  "logger_name": "gov.cdc.izgateway.xform.solutions.SolutionOperation",
  "thread_name": "https-jsse-nio-444-exec-4",
  "level": "DEBUG",
  "level_value": 10000,
  "ipAddress": "0:0:0:0:0:0:0:1",
  "eventId": "1280352333000.3",
  "commonName": "amoody.testing.izgateway.org",
  "sessionId": "D3145708D67023E2ABA663C9717A91F4",
  "requestUri": "/IISHubService",
  "method": "POST"
}
```

So `Solution-level precondition passed for Postman Test For State Precondition (REQUEST)` instead of `Solution-level precondition passed`.