### PR TITLE
chore: Specify swagger ui version

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,6 +76,7 @@ security:
 springdoc:
   swagger-ui:
     path: /swagger/ui.html
+    version: 5.32.5
   api-docs:
     path: /swagger/api-docs
   paths-to-match: /api/**


### PR DESCRIPTION
The izgw-bom 1.7.0-SNAPSHOT added an explicit org.webjars:swagger-ui:5.32.5 override (commit 183bfb89 on April 17), but springdoc-openapi 2.8.17 internally expects version 5.32.2 and configures its resource handler to look in that versioned directory. Since the actual webjar files are at .../5.32.5/ but springdoc is looking in .../5.32.2/, Spring returns a 404.

Specified version in application.yml similar to change in HUB (See PR https://github.com/IZGateway/izgw-hub/pull/142) where this same thing broke a swagger postman test in that application.