### PR TITLE
fix(ci): scope cleanup-on-failure to current run's actions only (IGDD-2398)

### DIFF
--- a/.github/workflows/_release_common.yml
+++ b/.github/workflows/_release_common.yml
@@ -158,10 +158,6 @@ jobs:
               exit 1
             fi
             RELEASE_BRANCH="release/$RELEASE_VERSION"
-            if git ls-remote --exit-code --heads origin "$RELEASE_BRANCH" >/dev/null 2>&1; then
-              echo "Error: release branch '$RELEASE_BRANCH' already exists"
-              exit 1
-            fi
           else
             if [[ ! "$CURRENT_BRANCH" =~ ^hotfix/ ]]; then
               echo "Error: hotfix release must run from a hotfix/* branch (current: $CURRENT_BRANCH)"
@@ -169,8 +165,14 @@ jobs:
             fi
             RELEASE_BRANCH="$CURRENT_BRANCH"
           fi
+          # Set output BEFORE existence checks so cleanup-on-failure has a defined value.
           echo "release_branch=$RELEASE_BRANCH" >> $GITHUB_OUTPUT
           echo "Release branch: $RELEASE_BRANCH"
+
+          if [[ "$RELEASE_TYPE" == "standard" ]] && git ls-remote --exit-code --heads origin "$RELEASE_BRANCH" >/dev/null 2>&1; then
+            echo "Error: release branch '$RELEASE_BRANCH' already exists"
+            exit 1
+          fi
 
           if git ls-remote --exit-code --tags origin "v$RELEASE_VERSION" >/dev/null 2>&1; then
             echo "Error: tag v$RELEASE_VERSION already exists"
@@ -195,6 +197,7 @@ jobs:
           echo "Note: SNAPSHOT internal dependencies (izgw-core, v2tofhir) are intentionally allowed for this project."
 
       - name: Create release branch
+        id: create-release-branch
         if: ${{ inputs.release-type == 'standard' }}
         env:
           BASE_BRANCH: ${{ inputs.base-branch }}
@@ -204,6 +207,7 @@ jobs:
           echo "Creating $RELEASE_BRANCH from $BASE_BRANCH"
           git checkout -b "$RELEASE_BRANCH"
           git push origin "$RELEASE_BRANCH"
+          echo "created=true" >> $GITHUB_OUTPUT
 
       - name: Generate release notes from PRs
         env:
@@ -436,6 +440,7 @@ jobs:
           destination_dir: ${{ steps.site-dirs.outputs.versioned_dir }}
 
       - name: Merge release branch to trunk
+        id: merge-trunk
         env:
           TRUNK_BRANCH: ${{ inputs.trunk-branch }}
           RELEASE_BRANCH: ${{ steps.validate.outputs.release_branch }}
@@ -450,16 +455,20 @@ jobs:
             git checkout -b "$TRUNK_BRANCH"
           fi
           git push origin "$TRUNK_BRANCH"
+          echo "merged=true" >> $GITHUB_OUTPUT
 
       - name: Create Git tag on trunk
+        id: tag-trunk
         env:
           RELEASE_VERSION: ${{ inputs.release-version }}
         run: |
           set -euo pipefail
           git tag -a "v$RELEASE_VERSION" -m "Release version $RELEASE_VERSION"
           git push origin "v$RELEASE_VERSION"
+          echo "tagged=true" >> $GITHUB_OUTPUT
 
       - name: Update base branch
+        id: update-base
         env:
           BASE_BRANCH: ${{ inputs.base-branch }}
           TRUNK_BRANCH: ${{ inputs.trunk-branch }}
@@ -519,6 +528,7 @@ jobs:
           fi
 
           git push origin "$BASE_BRANCH"
+          echo "updated=true" >> $GITHUB_OUTPUT
 
       - name: Generate GitHub Release body
         env:
@@ -536,6 +546,7 @@ jobs:
           } > GITHUB_RELEASE_BODY.md
 
       - name: Create GitHub Release
+        id: create-gh-release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ inputs.release-version }}
@@ -595,54 +606,115 @@ jobs:
           RELEASE_VERSION: ${{ inputs.release-version }}
           RELEASE_TYPE: ${{ inputs.release-type }}
           RELEASE_BRANCH: ${{ steps.validate.outputs.release_branch }}
+          BASE_BRANCH: ${{ inputs.base-branch }}
           TRUNK_BRANCH: ${{ inputs.trunk-branch }}
+          # Per-step "did THIS run actually do it?" gates. Each is "true" only if
+          # the corresponding step succeeded in the current workflow run.
+          THIS_RUN_CREATED_RELEASE_BRANCH: ${{ steps.create-release-branch.outputs.created }}
+          THIS_RUN_MERGED_TRUNK: ${{ steps.merge-trunk.outputs.merged }}
+          THIS_RUN_TAGGED: ${{ steps.tag-trunk.outputs.tagged }}
+          THIS_RUN_UPDATED_BASE: ${{ steps.update-base.outputs.updated }}
+          THIS_RUN_GH_RELEASE_ID: ${{ steps.create-gh-release.outputs.id }}
         run: |
           set +e
           echo "=========================================="
           echo "Cleanup of failed release"
           echo "=========================================="
+          echo "Per-run state gates:"
+          echo "  created release branch: ${THIS_RUN_CREATED_RELEASE_BRANCH:-false}"
+          echo "  merged to trunk:        ${THIS_RUN_MERGED_TRUNK:-false}"
+          echo "  tagged:                 ${THIS_RUN_TAGGED:-false}"
+          echo "  updated base branch:    ${THIS_RUN_UPDATED_BASE:-false}"
+          echo "  gh release id:          ${THIS_RUN_GH_RELEASE_ID:-<none>}"
           CLEANUP_WARNINGS=""
           CLEANUP_SUCCESSES=""
 
-          if git ls-remote --exit-code --tags origin "v$RELEASE_VERSION" >/dev/null 2>&1; then
+          # Delete tag ONLY if this run created it.
+          if [[ "$THIS_RUN_TAGGED" == "true" ]]; then
             if git push origin --delete "v$RELEASE_VERSION"; then
               CLEANUP_SUCCESSES="$CLEANUP_SUCCESSES\n- Git tag v$RELEASE_VERSION"
             else
-              CLEANUP_WARNINGS="$CLEANUP_WARNINGS\n- Git tag v$RELEASE_VERSION (deletion failed)"
+              CLEANUP_WARNINGS="$CLEANUP_WARNINGS\n- Git tag v$RELEASE_VERSION (deletion failed - MANUAL CLEANUP REQUIRED)"
             fi
+          else
+            echo "Skip tag deletion: this run did not create v$RELEASE_VERSION"
           fi
 
-          if git ls-remote --exit-code --heads origin "$TRUNK_BRANCH" >/dev/null 2>&1; then
+          # Revert trunk merge ONLY if this run merged it. The revert targets HEAD,
+          # which on a happy-path-then-fail is exactly our merge commit. If a manual
+          # commit landed on trunk between our merge and this cleanup (extremely rare
+          # for an automated workflow), the substring guard below still gives us a
+          # belt-and-suspenders check that we're reverting our own merge.
+          if [[ "$THIS_RUN_MERGED_TRUNK" == "true" ]]; then
             git fetch origin "$TRUNK_BRANCH"
             git checkout "$TRUNK_BRANCH"
             LAST_COMMIT_MSG=$(git log -1 --pretty=%B)
-            if [[ "$LAST_COMMIT_MSG" == *"Merge release branch $RELEASE_BRANCH"* ]]; then
+            if [[ -n "$RELEASE_BRANCH" && "$LAST_COMMIT_MSG" == *"Merge release branch $RELEASE_BRANCH"* ]]; then
               if git revert -m 1 HEAD --no-edit && git push origin "$TRUNK_BRANCH"; then
                 CLEANUP_SUCCESSES="$CLEANUP_SUCCESSES\n- $TRUNK_BRANCH merge revert"
               else
                 CLEANUP_WARNINGS="$CLEANUP_WARNINGS\n- $TRUNK_BRANCH merge (revert failed - MANUAL CLEANUP REQUIRED)"
               fi
+            else
+              CLEANUP_WARNINGS="$CLEANUP_WARNINGS\n- $TRUNK_BRANCH merge revert SKIPPED: HEAD is not our merge commit (something else landed on trunk; manual cleanup required)"
             fi
+          else
+            echo "Skip trunk revert: this run did not merge to $TRUNK_BRANCH"
           fi
 
-          if [[ "$RELEASE_TYPE" == "standard" ]]; then
-            if git ls-remote --exit-code --heads origin "$RELEASE_BRANCH" >/dev/null 2>&1; then
-              if git push origin --delete "$RELEASE_BRANCH"; then
-                CLEANUP_SUCCESSES="$CLEANUP_SUCCESSES\n- Release branch $RELEASE_BRANCH"
+          # Revert base branch update ONLY if this run pushed to it. Same belt-and-suspenders
+          # commit-message check as above. We revert the most recent merge from RELEASE_BRANCH.
+          # If we also bumped pom (standard release), the bump commit sits on top of the merge,
+          # so we revert that first, then the merge.
+          if [[ "$THIS_RUN_UPDATED_BASE" == "true" ]]; then
+            git fetch origin "$BASE_BRANCH"
+            git checkout "$BASE_BRANCH"
+            REVERTED_BASE=true
+            # Pop the SNAPSHOT bump if it's at HEAD (standard release only).
+            if git log -1 --pretty=%B | grep -q "^chore: bump version to "; then
+              if ! (git revert HEAD --no-edit && git push origin "$BASE_BRANCH"); then
+                CLEANUP_WARNINGS="$CLEANUP_WARNINGS\n- $BASE_BRANCH SNAPSHOT-bump revert failed - MANUAL CLEANUP REQUIRED"
+                REVERTED_BASE=false
+              fi
+            fi
+            if [[ "$REVERTED_BASE" == "true" ]]; then
+              LAST_COMMIT_MSG=$(git log -1 --pretty=%B)
+              if [[ -n "$RELEASE_BRANCH" && "$LAST_COMMIT_MSG" == *"Merge release branch $RELEASE_BRANCH"* ]]; then
+                if git revert -m 1 HEAD --no-edit && git push origin "$BASE_BRANCH"; then
+                  CLEANUP_SUCCESSES="$CLEANUP_SUCCESSES\n- $BASE_BRANCH merge revert"
+                else
+                  CLEANUP_WARNINGS="$CLEANUP_WARNINGS\n- $BASE_BRANCH merge revert failed - MANUAL CLEANUP REQUIRED"
+                fi
               else
-                CLEANUP_WARNINGS="$CLEANUP_WARNINGS\n- Release branch $RELEASE_BRANCH (deletion failed)"
+                CLEANUP_WARNINGS="$CLEANUP_WARNINGS\n- $BASE_BRANCH merge revert SKIPPED: HEAD is not our merge commit (manual cleanup required)"
               fi
             fi
           else
-            echo "Hotfix branch kept for investigation: $RELEASE_BRANCH"
+            echo "Skip base branch revert: this run did not push to $BASE_BRANCH"
           fi
 
-          if gh release view "v$RELEASE_VERSION" >/dev/null 2>&1; then
+          # Delete release branch ONLY if this run created it (standard releases only).
+          if [[ "$RELEASE_TYPE" == "standard" && "$THIS_RUN_CREATED_RELEASE_BRANCH" == "true" ]]; then
+            if [ -n "$RELEASE_BRANCH" ] && git push origin --delete "$RELEASE_BRANCH"; then
+              CLEANUP_SUCCESSES="$CLEANUP_SUCCESSES\n- Release branch $RELEASE_BRANCH"
+            else
+              CLEANUP_WARNINGS="$CLEANUP_WARNINGS\n- Release branch $RELEASE_BRANCH (deletion failed)"
+            fi
+          elif [[ "$RELEASE_TYPE" == "hotfix" ]]; then
+            echo "Hotfix branch kept for investigation: $RELEASE_BRANCH"
+          else
+            echo "Skip release branch deletion: this run did not create it"
+          fi
+
+          # Delete GitHub Release ONLY if this run created it (use softprops outputs.id as the gate).
+          if [[ -n "$THIS_RUN_GH_RELEASE_ID" ]]; then
             if gh release delete "v$RELEASE_VERSION" --yes; then
               CLEANUP_SUCCESSES="$CLEANUP_SUCCESSES\n- GitHub Release v$RELEASE_VERSION"
             else
               CLEANUP_WARNINGS="$CLEANUP_WARNINGS\n- GitHub Release v$RELEASE_VERSION (deletion failed)"
             fi
+          else
+            echo "Skip GH release deletion: this run did not create v$RELEASE_VERSION"
           fi
 
           {


### PR DESCRIPTION
The previous cleanup logic inferred what to undo from origin state and a substring match on the trunk branch's HEAD commit message. When validate- prerequisites failed early (e.g., duplicate tag/release-branch from a prior successful run), $RELEASE_BRANCH was empty, the substring match degenerated to '*Merge release branch *' which matched the prior run's merge, and the cleanup reverted state from that earlier successful run. Observed: a failure- path retest on the same release-version reverted mainalm and deleted the tag
+ draft release that the first successful dry-run had created.

Fix: each mutating step now sets a step output on success, and the cleanup step only undoes operations whose corresponding output is set in the current run. Specifically:
- create-release-branch.created (standard only)
- merge-trunk.merged
- tag-trunk.tagged
- update-base.updated
- create-gh-release.id (set natively by softprops/action-gh-release)

Also:
- validate-prerequisites now writes release_branch to GITHUB_OUTPUT BEFORE the existence checks, so cleanup has a defined value even on early exit.
- Added base-branch revert to cleanup (was previously a gap: a run that made it past 'Update base branch' but failed later left the base bumped without a complete release).
- Belt-and-suspenders commit-message check on the trunk + base reverts to guard against a stray manual commit landing between our merge and cleanup.