### PR TITLE
ci: disable OSS Index in dependency check

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -174,8 +174,9 @@ jobs:
 # 
 # Use GitHub Action to speed up and improve dependency checking
 # NOTE: Disable automatic dependency checking in the build, this replaces it          
+      # OSS Index disabled while Sonatype free credits are exhausted — see izgw-bom PR #77
       - name: Dependency Check
-        env:  
+        env:
         # Per https://github.com/marketplace/actions/dependency-check, fix JAVA_HOME location for action
           JAVA_HOME: /opt/jdk
         uses: dependency-check/Dependency-Check_Action@main
@@ -187,8 +188,7 @@ jobs:
           format: 'HTML'
           out: 'target/site'
           args: >
-            --ossIndexUsername ${{ secrets.OSS_INDEX_USERNAME }}
-            --ossIndexPassword ${{ secrets.OSS_INDEX_PASSWORD }} 
+            --disableOssIndex
             --failOnCVSS 7
             --suppression ./dependency-suppression.xml
             --nvdApiKey ${{ secrets.NVDAPIKEY }}


### PR DESCRIPTION
## Summary
- Sonatype OSS Index free credits are exhausted, causing the Dependency-Check action to fail and block all CI runs.
- Swap the `--ossIndexUsername` / `--ossIndexPassword` credentials for `--disableOssIndex`, matching the workaround already applied in [izgw-bom PR #77](https://github.com/IZGateway/izgw-bom/pull/77).
- NVD scanning is unaffected (`--nvdApiKey` is still passed), and the `--failOnCVSS 7` gate and `dependency-suppression.xml` still apply.

## Test plan
- [ ] CI run on this PR completes the `Dependency Check` step without the OSS Index credit-exhaustion error.
- [ ] Verify NVD-sourced findings still appear in `target/site/dependency-check-report.html` artifact.

## Notes
This is a temporary workaround until OSS Index credits are restored, or until we migrate to the shared `cve-scan` composite action from `izg-dependency-scripts` (tracked upstream as `IGDD-2563`).