### PR TITLE
IGDD-2972: Fix FHIR search endpoint conformance and add API documentation

### DIFF
--- a/docs/fhir/fhir-api.md
+++ b/docs/fhir/fhir-api.md
@@ -1,0 +1,203 @@
+# FHIR API Reference
+
+*Part of the [IZ Gateway FHIR Interface](index.md) documentation.*
+
+The FHIR facade is implemented in `FhirController` (`gov.cdc.izgateway.xform.endpoints.fhir`).
+All endpoints are rooted at `/fhir/{destinationId}/` where `{destinationId}` is the IIS
+destination identifier registered in the IZ Gateway Hub.
+
+---
+
+## Operations
+
+### Search
+
+Search for patient immunization data by demographics.
+
+```
+GET /fhir/{destinationId}/Immunization
+GET /fhir/{destinationId}/ImmunizationRecommendation
+GET /fhir/{destinationId}/Patient
+```
+
+The resource type in the URL determines the query profile sent to the IIS:
+
+| URL resource type | V2 profile | IIS query name |
+|---|---|---|
+| `Immunization` | Z34 | Request Immunization History |
+| `ImmunizationRecommendation` | Z44 | Request Evaluated History and Forecast |
+| `Patient` | Z34 | Request Immunization History |
+
+In all cases, the IIS is queried for a patient chart using the supplied demographics.
+The returned Bundle is then filtered to the requested resource type.
+
+> **POST search:** The FHIR specification defines `POST /[type]/_search` (with an
+> `application/x-www-form-urlencoded` body) as the standard POST search pattern.
+> This service supports both `GET /[type]?params` and `POST /[type]/_search` per the
+> FHIR R4 specification.
+
+#### Query Parameters
+
+See [FHIR Query → QBP Mapping](fhir-to-qbp.md) for the complete parameter list and
+how each maps to the QPD segment fields in the IIS query message.
+
+Minimum required parameters (either, not both):
+- A patient identifier: `patient.identifier` (or `patient` as a reference)
+- Patient name **and** birth date: `patient.family` + `patient.given` + `patient.birthdate`
+
+Additional demographics (`patient.gender`, `patient.address.*`, `patient.phone`, etc.)
+are passed to the IIS as query hints; their use depends on the IIS implementation.
+
+#### Limiting result count
+
+```
+_count=N
+```
+
+Where `N` is between 1 and 10 (default 5). Maps to the `RCP` segment quantity limit
+in the QBP message.
+
+#### Including additional resources
+
+By default the Bundle contains only the requested resource type (e.g., `Immunization`
+records) and any warnings. Use `_include` to add related resources.
+
+**Use case: I want everything — immunization records and all referenced resources**
+
+```
+GET /fhir/{destinationId}/Immunization?family=Smith&given=John&birthdate=2000-01-01
+    &_include=*:*
+    &_revinclude=Provenance:target
+```
+
+`_include=*:*` follows all references from all returned resources. Adding
+`_revinclude=Provenance:target` also includes a `Provenance` record for each result
+identifying the IIS as the data source.
+
+**Use case: I want immunization records and the patient only**
+
+```
+GET /fhir/{destinationId}/Immunization?family=Smith&given=John&birthdate=2000-01-01
+    &_include=Immunization:patient
+```
+
+**Use case: I want immunization records and the administering provider or organization**
+
+```
+GET /fhir/{destinationId}/Immunization?family=Smith&given=John&birthdate=2000-01-01
+    &_include=Immunization:patient
+    &_include=Immunization:performer
+```
+
+> In the response Bundle, directly matched resources have `search.mode = match`;
+> included resources have `search.mode = include`; warnings have `search.mode = outcome`.
+
+
+#### Response
+
+A `Bundle` of type `searchset`. Any IIS error or warning is returned as an
+`OperationOutcome` entry with `search.mode = outcome`.
+
+---
+
+### Read
+
+Retrieve a previously found resource by its ID.
+
+```
+GET /fhir/{destinationId}/Immunization/{id}
+GET /fhir/{destinationId}/ImmunizationRecommendation/{id}
+GET /fhir/{destinationId}/Patient/{id}
+```
+
+The `{id}` is a Base64-encoded token returned by a prior search or `$match` operation.
+The service decodes the ID to reconstruct the original patient identifier, re-queries the
+IIS, and returns the specific resource from the resulting chart.
+
+> **Note:** `ImmunizationRecommendation` resources are forecast data and may change over
+> time. A read on a recommendation ID that was valid at a prior date may return different
+> content or `404 Not Found` if the forecast has been updated.
+
+Responses:
+- `200 OK` — resource found, returns the single resource
+- `404 Not Found` — resource not found; body is an `OperationOutcome`
+
+---
+
+### Patient/$match
+
+Perform a probabilistic patient match query against the IIS.
+
+```
+POST /fhir/{destinationId}/Patient/$match
+```
+
+Request body must be either:
+- A `Patient` resource containing the search demographics, or
+- A `Parameters` resource with:
+  - `resource` — a `Patient` resource
+  - `onlySingleMatch` (boolean, optional) — return at most one result
+  - `onlyCertainMatches` (boolean, optional) — return only high-confidence matches
+  - `count` (integer 1–10, optional) — maximum number of results
+
+The service converts the `Patient` resource fields to the same QPD parameters used by
+the search operation (see [FHIR Query → QBP Mapping](fhir-to-qbp.md)) and sends a Z34
+query to the IIS. Results are scored by match quality and returned as a `Bundle` of
+`Patient` resources.
+
+Responses:
+- `200 OK` — Bundle of matched Patient resources with match scores
+- `400 Bad Request` — body is `OperationOutcome` describing invalid input
+- `500 Internal Server Error` — unexpected failure
+
+---
+
+## Connection Test
+
+SMART on FHIR and other auth clients test connectivity with:
+
+```
+GET /fhir/{destinationId}/Patient?_summary=count&_count=1
+```
+
+The service short-circuits this call and returns an empty `searchset` Bundle with
+`total=100` without contacting the IIS.
+
+---
+
+## Response Formats
+
+All endpoints accept an `Accept` header to select the format.
+
+| Accept header | Format |
+|---|---|
+| `application/fhir+json` | FHIR JSON (preferred) |
+| `application/fhir+xml` | FHIR XML |
+| `application/fhir+yaml` | FHIR YAML |
+| `application/json` | JSON alias |
+| `application/xml` | XML alias |
+| `text/xml` | XML alias |
+
+---
+
+## Error Handling
+
+| Condition | HTTP status | Body |
+|---|---|---|
+| IIS SOAP fault | `200` with `OperationOutcome` entry in Bundle | Bundle |
+| Invalid query parameters | `400 Bad Request` | `OperationOutcome` |
+| Resource not found (read) | `404 Not Found` | `OperationOutcome` |
+| HL7 parse error | `500` | exception propagated |
+| Unexpected exception | `500` | exception propagated |
+
+---
+
+## Authentication
+
+Callers must authenticate with a valid client certificate trusted by the Transformation
+Service and hold one of the following roles:
+
+- `XFORM_SENDING_SYSTEM`
+- `ADMIN`
+
+See [QUICK_START.md](../QUICK_START.md) for certificate and configuration details.

--- a/docs/fhir/fhir-to-qbp.md
+++ b/docs/fhir/fhir-to-qbp.md
@@ -1,0 +1,164 @@
+# FHIR Query → QBP Mapping
+
+*Part of the [IZ Gateway FHIR Interface](index.md) documentation.*
+
+When a FHIR search or `Patient/$match` request arrives, the Transformation Service
+builds an HL7 V2.5.1 `QBP_Q11` message and populates the `QPD` segment (Patient
+Demographics Query) from the FHIR search parameters. This document describes that
+mapping.
+
+Reference: [CDC HL7 Version 2.5.1 Implementation Guide for Immunization Messaging §3.3](https://repository.immregistries.org/files/resources/5bef530428317/hl7_2_5_1_release_1_5__2018_update.pdf)
+
+---
+
+## QBP Message Structure
+
+Every IIS query uses message type `QBP_Q11`. The profile identifier in `MSH-21`
+determines the type of history requested:
+
+| Profile | Description |
+|---|---|
+| `Z34` | Request Immunization History — returns `Immunization` resources |
+| `Z44` | Request Evaluated History and Forecast — returns `ImmunizationRecommendation` resources |
+
+### Fixed MSH Fields
+
+The following MSH fields are set by the service for every outbound query:
+
+| Field | Value |
+|---|---|
+| MSH-9 (Message Type) | `QBP^Q11^QBP_Q11` |
+| MSH-10 (Message Control ID) | ULID (unique per request) |
+| MSH-12 (Version ID) | `2.5.1` |
+| MSH-15 (Accept Ack Type) | `ER` |
+| MSH-16 (App Ack Type) | `AL` |
+| MSH-18 (Character Set) | *(default)* |
+| MSH-21 (Profile Identifier) | `Z34` or `Z44`, namespace `CDCPHINVS` |
+| MSH-3 (Sending Application) | Caller's principal name |
+| MSH-4 (Sending Facility) | Caller's organization |
+| MSH-5 (Receiving Application) | Configured `v2tofhir.receivingApplication` |
+| MSH-6 (Receiving Facility) | Configured `v2tofhir.receivingFacility` |
+| MSH-11 (Processing ID) | `P` (production) |
+
+### Fixed QPD Fields
+
+| Field | Value |
+|---|---|
+| QPD-1 (Message Query Name) | Profile code (`Z34` / `Z44`), text, system `CDCPHINVS` |
+| QPD-2 (Query Tag) | ULID (unique per request) |
+
+### Fixed RCP Fields
+
+The `RCP` (Response Control Parameters) segment controls the number of records returned:
+
+| Field | Value |
+|---|---|
+| RCP-2.1 (Quantity) | Value of `_count` parameter (default `5`, max `10`) |
+| RCP-2.2 (Units) | `RD` (records), system `HL70126` |
+
+---
+
+## FHIR Search Parameter → QPD Field Mapping
+
+### Minimum Required
+
+A valid query must supply **at least one** of:
+1. A patient identifier (`patient.identifier` or `patient` as a reference)
+2. Patient name (`patient.family` + `patient.given`) **and** birth date (`patient.birthdate`)
+
+Omitting both causes a `400 Bad Request`.
+
+### Parameter Table
+
+| FHIR Search Parameter | QPD Field | CDC Guide Field Name | Notes |
+|---|---|---|---|
+| `patient` *(reference)* | QPD-3 | PatientList | Reference value decoded to `system\|value`; type forced to `MR` |
+| `patient.identifier` | QPD-3 | PatientList | Repeatable; format `system\|value` |
+| `patient.family` | QPD-4.1 | PatientName — Family | One value; name type `L` (legal) |
+| `patient.given` | QPD-4.2 / QPD-4.3 | PatientName — Given / Middle | First occurrence → given name; second → middle name |
+| `patient.suffix` | QPD-4.4 | PatientName — Suffix | One value |
+| `patient.mothers-maiden-name` | QPD-5 | PatientMothersMaidenName | Family name component; name type `M` |
+| `patient.mothers-maiden-name-given` | QPD-5 (given) | PatientMothersMaidenName | Round-trip support only |
+| `patient.mothers-maiden-name-suffix` | QPD-5 (suffix) | PatientMothersMaidenName | Round-trip support only |
+| `patient.birthdate` | QPD-6 | PatientDateOfBirth | Normalized to `yyyyMMdd` |
+| `patient.gender` | QPD-7 | PatientSex | FHIR code first character; `U` if blank |
+| `patient.address` | QPD-8.1 / QPD-8.2 | PatientAddress — Street | Street address line(s); address type `L` (legal) |
+| `patient.address-city` | QPD-8.3 | PatientAddress — City | One value |
+| `patient.address-state` | QPD-8.4 | PatientAddress — State | One value |
+| `patient.address-postalcode` | QPD-8.5 | PatientAddress — Postal Code | One value |
+| `patient.address-country` | QPD-8.6 | PatientAddress — Country | One value |
+| `patient.phone` | QPD-9 | PatientHomePhone | Telephone number string |
+| `patient.multipleBirth-indicator` | QPD-10 | PatientMultipleBirthIndicator | `Y` or `N` |
+| `patient.multipleBirth-order` | QPD-11 | PatientBirthOrder | Integer birth order |
+| `_count` | RCP-2 | *(quantity limit)* | Integer 1–10; default 5 |
+| `_summary`, other `_` params | *(ignored)* | — | Except `_count`; special `_summary=count` triggers connection test |
+
+---
+
+## QPD Segment Layout
+
+The table below shows the full QPD field layout as specified in the CDC guide and how
+the Transformation Service populates each field.
+
+| QPD Field | CDC Field Name | Population Source |
+|---|---|---|
+| QPD-1 | MessageQueryName | Profile code (Z34 or Z44) |
+| QPD-2 | QueryTag | ULID |
+| QPD-3 | PatientList (CX) | `patient` / `patient.identifier` |
+| QPD-4 | PatientName (XPN) | `patient.family`, `patient.given`, `patient.suffix` |
+| QPD-5 | PatientMothersMaidenName (XPN) | `patient.mothers-maiden-name` |
+| QPD-6 | PatientDateOfBirth (TS) | `patient.birthdate` |
+| QPD-7 | PatientSex (IS) | `patient.gender` |
+| QPD-8 | PatientAddress (XAD) | `patient.address*` |
+| QPD-9 | PatientHomePhone (XTN) | `patient.phone` |
+| QPD-10 | PatientMultipleBirthIndicator (ID) | `patient.multipleBirth-indicator` |
+| QPD-11 | PatientBirthOrder (NM) | `patient.multipleBirth-order` |
+
+---
+
+## Patient/$match Parameter Extraction
+
+When a `Patient/$match` request is received, the service extracts QPD parameters from
+the submitted `Patient` resource as follows:
+
+| Patient resource field | FHIR search parameter used |
+|---|---|
+| `Patient.identifier` | `patient.identifier` |
+| `Patient.name[0].family` | `patient.family` |
+| `Patient.name[0].given` | `patient.given` (one call per given name) |
+| `Patient.name[0].suffix` | `patient.suffix` |
+| Extension: `mothers-maiden-name` | `patient.mothers-maiden-name` |
+| `Patient.birthDate` | `patient.birthdate` |
+| `Patient.gender` | `patient.gender` |
+| `Patient.address[0].line` | `patient.address` |
+| `Patient.address[0].city` | `patient.address-city` |
+| `Patient.address[0].state` | `patient.address-state` |
+| `Patient.address[0].postalCode` | `patient.address-postalcode` |
+| `Patient.address[0].country` | `patient.address-country` |
+| `Patient.multipleBirth` (boolean) | `patient.multipleBirth-indicator` |
+| `Patient.multipleBirth` (integer) | `patient.multipleBirth-order` |
+
+---
+
+## Example QBP Message
+
+The following is a representative QBP_Q11 Z34 message generated for:
+
+```
+GET /fhir/dev/Immunization
+    ?patient.family=Johnson
+    &patient.given=James
+    &patient.birthdate=2016-04-14
+    &patient.gender=male
+    &patient.address=123 Main Street
+    &patient.address-city=New Orleans
+    &patient.address-state=LA
+    &patient.address-postalcode=70115
+    &patient.phone=555-5551111
+```
+
+```
+MSH|^~\&|CallerPrincipal|CallerOrg|IIS_App|IIS_Facility|20260528143000||QBP^Q11^QBP_Q11|01JXXXXXXXXXXXXXXXXXX|P|2.5.1|||ER|AL|||||Z34^CDCPHINVS
+QPD|Z34^Request Immunization History^CDCPHINVS|01JXXXXXXXXXXXXXXXXXY|||Johnson^James^^^^L||20160414|M|123 Main Street^^New Orleans^LA^70115^^L|^PRN^PH^^^555^5551111
+RCP|I|5^RD^HL70126
+```

--- a/docs/fhir/index.md
+++ b/docs/fhir/index.md
@@ -1,0 +1,82 @@
+# IZ Gateway Transformation Service — FHIR Interface
+
+The IZ Gateway Transformation Service exposes a FHIR R4 API that allows any FHIR-capable
+client to query an Immunization Information System (IIS). The service translates each FHIR
+request into an HL7 Version 2.5.1 QBP message following the
+[CDC HL7 Version 2.5.1 Implementation Guide for Immunization Messaging](https://repository.immregistries.org/files/resources/5bef530428317/hl7_2_5_1_release_1_5__2018_update.pdf),
+forwards it to the target IIS through the IZ Gateway Hub, and converts the RSP response back
+to FHIR resources.
+
+## How It Works
+
+```
+FHIR Client
+    │  GET /fhir/{destinationId}/Immunization?patient.family=...
+    ▼
+FhirController (izgw-transform)
+    │  builds QBP_Q11 (Z34 or Z44)
+    ▼
+IZ Gateway Hub → IIS
+    │  RSP_K11 response
+    ▼
+v2tofhir MessageParser
+    │  converts RSP segments → FHIR Bundle
+    ▼
+FhirController
+    │  adjusts resource IDs, filters to requested type
+    ▼
+FHIR Client receives Bundle (SearchSet)
+```
+
+The conversion library ([v2tofhir](https://github.com/IZGateway/v2tofhir)) performs the
+segment-level mapping. This documentation covers the end-to-end behavior as seen by a
+FHIR client.
+
+## Documents
+
+| Document | Description |
+|---|---|
+| [FHIR API Reference](fhir-api.md) | Endpoints, operations, query parameters, response format |
+| [FHIR Query → QBP Mapping](fhir-to-qbp.md) | How each FHIR search parameter maps to QPD fields in the IIS query |
+| [RSP → FHIR Resource Mapping](rsp-to-fhir.md) | How IIS response segments map to FHIR resources in the returned Bundle |
+
+## Supported Resources
+
+All resources are returned from a single IIS query. The primary resource type requested
+determines whether a Z34 (Immunization History) or Z44 (Evaluated History and Forecast)
+query is sent.
+
+| FHIR Resource | Source V2 Segments | IIS Query Type |
+|---|---|---|
+| `Patient` | PID, PD1 | Z34 or Z44 |
+| `Immunization` | ORC, RXA, RXR, OBX | Z34 |
+| `ImmunizationRecommendation` | ORC, RXA, RXR, OBX | Z44 |
+| `ServiceRequest` | ORC | Z34 or Z44 |
+| `Organization` | MSH, ORC-21/23, PD1-4 | Z34 or Z44 |
+| `Practitioner` | ORC-12/21, RXA-10, PV1-7/8/9, OBX-16/25 | Z34 or Z44 |
+| `PractitionerRole` | ORC-12/21/23, OBX-15/16/25 | Z34 or Z44 |
+| `Location` | ORC-29, RXA-11/27/28, PV1-3/6/11/37 | Z34 or Z44 |
+| `RelatedPerson` | NK1 | Z34 or Z44 |
+| `Encounter` | PV1 | Z34 or Z44 |
+| `Account` | PID-18 | Z34 or Z44 |
+
+## Resource ID Design
+
+FHIR resource IDs returned by the service are stable, opaque, Base64-encoded strings
+derived from the V2 identifiers in the IIS response. A `Patient` ID encodes
+`system|value` from the first patient identifier. Non-patient resource IDs encode
+`patientSystem|patientValue|resourceSystem|resourceValue`, tying every resource back
+to the patient chart that produced it.
+
+This means a resource retrieved today can be re-read tomorrow — as long as the IIS
+still has the data — using a standard FHIR read (`GET /fhir/{dest}/{ResourceType}/{id}`).
+
+## Conventions
+
+- All endpoints are under `/fhir/{destinationId}/` where `destinationId` is the IIS
+  destination identifier configured in the IZ Gateway Hub.
+- Requests may use `GET`, `POST /_search`, or `HEAD`.
+- Responses are available as `application/fhir+json`, `application/fhir+xml`,
+  `application/fhir+yaml`, and several plain media type aliases.
+- The service requires mTLS authentication. Callers must hold a role of
+  `XFORM_SENDING_SYSTEM` or `ADMIN`.

--- a/docs/fhir/rsp-to-fhir.md
+++ b/docs/fhir/rsp-to-fhir.md
@@ -1,0 +1,345 @@
+# RSP → FHIR Resource Mapping
+
+*Part of the [IZ Gateway FHIR Interface](index.md) documentation.*
+
+When the IIS returns an RSP_K11 response message, the v2tofhir `MessageParser` converts
+each V2 segment into one or more FHIR resources. This document describes those mappings
+at the field level.
+
+Reference: [CDC HL7 Version 2.5.1 Implementation Guide for Immunization Messaging](https://repository.immregistries.org/files/resources/5bef530428317/hl7_2_5_1_release_1_5__2018_update.pdf)
+
+---
+
+## Bundle Structure
+
+The `MessageParser` converts the entire RSP message into a single FHIR `Bundle`. After
+conversion, `FhirController` performs two post-processing steps:
+
+1. **`adjustIdentifiers`** — rewrites each resource's FHIR ID to an opaque, stable,
+   Base64-encoded token derived from the V2 identifiers (see
+   [Resource ID Design](index.md#resource-id-design)).
+2. **`filter`** — reduces the bundle to the requested resource type (plus any resources
+   requested via `_include` / `_revinclude`), sets `Bundle.type = searchset`, and marks
+   each entry with `search.mode`.
+
+The segment parsers that produce each resource type are listed below.
+
+---
+
+## MSH → MessageHeader / Organization / Endpoint / Bundle
+
+**Parser:** `MSHParser`
+
+| V2 Field | FHIR Target | Notes |
+|---|---|---|
+| MSH-3 | `MessageHeader.source` (Endpoint) | Sending application → source endpoint |
+| MSH-3 | `Organization` (sender) | Sending application name |
+| MSH-4 | `Organization` (sender facility) | Sending facility |
+| MSH-5 | `MessageHeader.destination` (Endpoint) | Receiving application |
+| MSH-6 | `Organization` (receiver facility) | Receiving facility |
+| MSH-7 | `Bundle.timestamp` | Message date/time |
+| MSH-9.1 | `MessageHeader.meta.tag` | Message code |
+| MSH-9.2 | `MessageHeader.eventCoding` | Trigger event |
+| MSH-9.3 | `Bundle.implicitRules`, `MessageHeader.definition` | Message structure profile |
+| MSH-10 | `Bundle.identifier` | Message control ID |
+| MSH-21 | `Bundle.meta.profile` | Message profile identifier |
+| MSH-22 | `MessageHeader.responsible` | Sending responsible organization |
+| MSH-23 | `Organization` (destination receiver) | Receiving responsible organization |
+| MSH-8 / MSH-26 / MSH-27 / MSH-28 | `MessageHeader.meta.security` | Security labels |
+
+---
+
+## QAK → OperationOutcome
+
+**Parser:** `QAKParser`
+
+| V2 Field | FHIR Target | Notes |
+|---|---|---|
+| QAK-1 | `OperationOutcome` (meta.tag, system `QueryTag`) | Query tag echo |
+| QAK-2 | `OperationOutcome.issue.details` | Query response status (`OK`, `NF`, `AE`, `AR`) |
+| QAK-2 | `OperationOutcome.issue.code` / `.severity` | Derived from status code |
+
+Query response codes:
+- `OK` — data found; `information` / `informational`
+- `NF` — not found; `warning` / `not-found`
+- `AE` / `AR` — application/access error; `error` / `processing`
+
+---
+
+## QPD → Parameters (echo)
+
+**Parser:** `QPDParser`
+
+The query parameters are echoed back in the RSP. The parser converts the QPD into a
+FHIR `Parameters` resource. For the QBP request side it also emits a
+`Bundle.entry.request` with a reconstructed GET URL; for the RSP side it emits a
+`Bundle.entry.response.location`.
+
+---
+
+## PID → Patient / RelatedPerson / Account
+
+**Parser:** `PIDParser`
+
+### Patient fields
+
+| V2 Field | FHIR Element | Notes |
+|---|---|---|
+| PID-2, PID-3, PID-4, PID-20 | `Patient.identifier` | All patient identifier lists |
+| PID-5 | `Patient.name` | Legal name (name use `usual`) |
+| PID-6 | Extension: `patient-mothers-maiden-name` | Mother's maiden name |
+| PID-7 | `Patient.birthDate` | Date portion |
+| PID-7 | Extension: `patient-birth-time` | Time portion, if present |
+| PID-8 | `Patient.gender` | Mapped from HL7 administrative sex table |
+| PID-9 | `Patient.name` (alias) | Alias name |
+| PID-10 | US Core Race Extension | Race category and detail |
+| PID-11 | `Patient.address` | Legal address (address type `L`) |
+| PID-12 | `Patient.address.district` | County code |
+| PID-13 | `Patient.telecom` | Home phone(s) |
+| PID-14 | `Patient.telecom` | Business phone(s) |
+| PID-15 | `Patient.communication.language` | Primary language |
+| PID-16 | `Patient.maritalStatus` | Marital status code |
+| PID-17 | Extension: `patient-religion` | Religion code |
+| PID-19 | `Patient.identifier` | SSN identifier |
+| PID-23 | Extension: `patient-birthPlace` | Birth place |
+| PID-24 | `Patient.multipleBirthBoolean` | Multiple birth indicator |
+| PID-25 | `Patient.multipleBirthInteger` | Birth order |
+| PID-26, PID-39 | Extension: `patient-citizenship` | Citizenship |
+| PID-28 | Extension: `patient-nationality` | Nationality |
+| PID-29 | `Patient.deceasedDateTime` | Date/time of death |
+| PID-30 | `Patient.deceasedBoolean` | Deceased indicator |
+| PID-33 | `Patient.meta.lastUpdated` | Last update date/time |
+| PID-40 | `Patient.telecom` | Other telecom |
+
+### RelatedPerson (mother)
+
+| V2 Field | FHIR Element | Notes |
+|---|---|---|
+| PID-21 | `RelatedPerson.identifier` | Mother's identifier |
+
+### Account
+
+| V2 Field | FHIR Element | Notes |
+|---|---|---|
+| PID-18 | `Account.identifier` | Patient account number |
+
+---
+
+## NK1 → RelatedPerson
+
+**Parser:** `NK1Parser`
+
+| V2 Field | FHIR Element | Notes |
+|---|---|---|
+| NK1-2 | `RelatedPerson.name` | Next-of-kin name |
+| NK1-3, NK1-7 | `RelatedPerson.relationship` | Relationship codes |
+| NK1-4, NK1-32 | `RelatedPerson.address` | Address |
+| NK1-5, NK1-31, NK1-40, NK1-41 | `RelatedPerson.telecom` | Phone/contact |
+| NK1-6 | `RelatedPerson.telecom` | Business phone |
+| NK1-8, NK1-9 | `RelatedPerson.period` | Effective period start/end |
+| NK1-12, NK1-33 | `RelatedPerson.identifier` | Identifiers |
+| NK1-15 | `RelatedPerson.gender` | Administrative sex |
+| NK1-16 | `RelatedPerson.birthDate` | Date of birth |
+| NK1-20 | `RelatedPerson.communication.language` | Language |
+| NK1-30 | `RelatedPerson.name` | Mother's maiden name |
+| NK1-37 | `RelatedPerson.identifier` | SSN |
+
+---
+
+## ORC → ServiceRequest / Practitioner / Organization
+
+**Parser:** `ORCParser`
+
+### ServiceRequest
+
+| V2 Field | FHIR Element | Notes |
+|---|---|---|
+| ORC-1 | `ServiceRequest.status` | Order control code mapping |
+| ORC-2, ORC-33 | `ServiceRequest.identifier` | Placer order number |
+| ORC-3 | `ServiceRequest.identifier` | Filler order number (primary identifier) |
+| ORC-4 | `ServiceRequest.identifier` | Placer group number |
+| ORC-5 | `ServiceRequest.status` | Order status |
+| ORC-8 | `ServiceRequest.identifier` | Parent order number |
+| ORC-9 | `ServiceRequest.authoredOn` | Date/time of transaction |
+| ORC-28 | `ServiceRequest.meta.security` | Confidentiality code |
+| ORC-29 | `ServiceRequest.locationCode` | Order location |
+
+### Practitioner (requester)
+
+| V2 Field | FHIR Element | Notes |
+|---|---|---|
+| ORC-12 | `Practitioner` / `ServiceRequest.requester` | Ordering provider |
+| ORC-21 | `Organization` / `ServiceRequest.requester` | Ordering organization |
+| ORC-22 | `Organization.address` | Ordering organization address |
+| ORC-23 | `Organization.telecom` | Ordering organization phone |
+
+---
+
+## RXA → Immunization / ImmunizationRecommendation
+
+**Parser:** `RXAParser`
+
+The same RXA segment populates either an `Immunization` (Z34 response) or
+`ImmunizationRecommendation` (Z44 response) resource depending on the query profile.
+
+### Immunization fields
+
+| V2 Field | FHIR Element | Notes |
+|---|---|---|
+| RXA-3 | `Immunization.occurrenceDateTime` | Date/time of administration |
+| RXA-5 | `Immunization.vaccineCode` | Vaccine administered code (CVX) |
+| RXA-6 | `Immunization.doseQuantity.value` | Dose amount |
+| RXA-7 | `Immunization.doseQuantity.unit` / `.code` | Dose units |
+| RXA-10 | `Immunization.performer` (Practitioner) | Administering provider |
+| RXA-11 | `Immunization.location` (Location) | Administering location |
+| RXA-15 | `Immunization.lotNumber` | Lot number |
+| RXA-16 | `Immunization.expirationDate` | Expiration date |
+| RXA-17 | `Immunization.manufacturer` (Organization) | Vaccine manufacturer |
+| RXA-18 | `Immunization.statusReason` / `status = not-done` | Refusal/exemption reason |
+| RXA-19 | `Immunization.reasonCode` | Indication (e.g., catch-up) |
+| RXA-20 | `Immunization.status` | Completion status |
+| RXA-21 | `Immunization.status` | Action code |
+| RXA-22 | `Immunization.recorded` | Date vaccine information recorded |
+| RXA-27 | `Immunization.location` (Location) | Administered-at location |
+| RXA-28 | `Location.address` | Location address |
+
+### ImmunizationRecommendation fields
+
+| V2 Field | FHIR Element | Notes |
+|---|---|---|
+| RXA-3 | `recommendation.dateCriterion` | Forecast date |
+| RXA-5 | `recommendation.vaccineCode` | Recommended vaccine code |
+| RXA-22 | `recommendation.dateCriterion` | Next dose date |
+
+---
+
+## RXR → Immunization route and site
+
+**Parser:** `RXRParser`
+
+| V2 Field | FHIR Element | Notes |
+|---|---|---|
+| RXR-1 | `Immunization.route` | Route of administration (HL7 table 0162) |
+| RXR-2 | `Immunization.site` | Body site (HL7 table 0163) |
+
+---
+
+## OBX → Observation / Immunization / ImmunizationRecommendation
+
+**Parser:** `OBXParser`
+
+OBX segments carry supplemental observations about an administered vaccine (Z34) or
+forecast recommendation (Z44). The observation type code (`OBX-3`) determines whether
+the value is attached to the parent `Immunization`, folded into the
+`ImmunizationRecommendation`, or emitted as a standalone `Observation`.
+
+### General observation fields
+
+| V2 Field | FHIR Element | Notes |
+|---|---|---|
+| OBX-2 | *(type discriminator)* | Data type (NM, ST, CE, TS, etc.) |
+| OBX-3 | `Observation.code` | Observation identifier (LOINC or local) |
+| OBX-5 | `Observation.value[x]` | Value, type-dependent |
+| OBX-6 | `Observation.valueQuantity.unit` | Unit of measure |
+| OBX-7 | `Observation.referenceRange` | Reference range |
+| OBX-8 | `Observation.interpretation` | Abnormal flag |
+| OBX-10 | Extension: `abnormal-test` | Abnormal test indicator |
+| OBX-11 | `Observation.status` | Observation status |
+| OBX-14 | `Observation.effectiveDateTime` | Observation date/time |
+| OBX-15 | `Observation.performer` (Organization) | Responsible organization identifier |
+| OBX-16 | `Observation.performer` (Practitioner) | Responsible practitioner |
+| OBX-17 | `Observation.method` | Method |
+| OBX-18 | `Observation.device` | Device identifier |
+| OBX-19 | `Observation.issued` | Analysis date/time |
+| OBX-20 | `Observation.bodySite` | Body site |
+| OBX-21 | `Observation.identifier` | Observation identifier |
+| OBX-23 | `Organization.name` | Performing organization name |
+| OBX-24 | `Organization.address` | Performing organization address |
+| OBX-25 | `Practitioner` | Medical director |
+| OBX-33 | `Specimen.identifier` | Specimen identifier |
+
+### Immunization-specific OBX codes
+
+Certain LOINC or CDC PHIN-coded OBX observations are applied directly to the parent
+`Immunization` resource:
+
+| OBX-3 code | FHIR target | Description |
+|---|---|---|
+| `64994-7` (LOINC) | `Immunization.fundingSource` | Vaccine funding source |
+| `30956-7` (LOINC) | `Immunization.education` | Vaccine information statement (VIS) |
+| `VFC eligibility` | `Immunization.programEligibility` | VFC eligibility category |
+
+### ImmunizationRecommendation forecast OBX codes (Z44 response)
+
+| OBX-3 code | FHIR target | Description |
+|---|---|---|
+| `59779-9` (LOINC) | `recommendation.forecastStatus` | Series status |
+| `59780-7` (LOINC) | `recommendation.doseNumber` | Dose number in series |
+| `59781-5` (LOINC) | `recommendation.seriesDoses` | Recommended number of doses |
+| `59782-3` (LOINC) | `recommendation.series` | Series name |
+| `30956-7` (LOINC) | `recommendation.vaccineCode` | Recommended vaccine code |
+| Next dose date codes | `recommendation.dateCriterion` | Earliest/recommended/latest dates |
+
+---
+
+## PV1 → Encounter / Location
+
+**Parser:** `PV1Parser`
+
+### Encounter fields
+
+| V2 Field | FHIR Element | Notes |
+|---|---|---|
+| PV1-2 | `Encounter.class` / `Encounter.type` | Patient class |
+| PV1-4 | `Encounter.type` | Admission type |
+| PV1-5 | `Encounter.identifier` | Pre-admit number |
+| PV1-7, PV1-8, PV1-9, PV1-17, PV1-52 | `Encounter.participant` (Practitioner) | Attending / referring / consulting / admitting providers |
+| PV1-10 | `Encounter.serviceType` | Hospital service |
+| PV1-13 | `Encounter.hospitalization.reAdmission` | Re-admission indicator |
+| PV1-14 | `Encounter.hospitalization.admitSource` | Admit source |
+| PV1-15 | `Encounter.extension` (ambulatory status) | Ambulatory status |
+| PV1-16 | `Encounter.extension` (VIP indicator) | VIP indicator |
+| PV1-19 | `Encounter.identifier` | Visit number |
+| PV1-36 | `Encounter.hospitalization.dischargeDisposition` | Discharge disposition |
+| PV1-38 | `Encounter.hospitalization.dietPreference` | Diet preference |
+| PV1-44 | `Encounter.period.start` | Admit date/time |
+| PV1-45 | `Encounter.period.end` | Discharge date/time |
+| PV1-50 | `Encounter.identifier` | Alternate visit ID |
+| PV1-54 | `Encounter.episodeOfCare` | Episode of care |
+
+### Location fields
+
+| V2 Field | FHIR Element | Source Segments | Notes |
+|---|---|---|---|
+| PV1-3 | `Location` (assigned) | PV1 | Current bed/room |
+| PV1-6 | `Location` (prior) | PV1 | Prior location |
+| PV1-11 | `Location` (temporary) | PV1 | Temporary location |
+| PV1-37 | `Location` (discharged to) | PV1 | Discharge destination |
+| PV1-40 | `Location.operationalStatus` | PV1 | Bed status |
+| PV1-42 | `Location` (pending) | PV1 | Pending location |
+| PV1-43 | `Location` (prior temporary) | PV1 | Prior temporary location |
+| ORC-29 | `Location` | ORC | Order location |
+| RXA-11 | `Location` | RXA | Administering location |
+| RXA-27 | `Location` | RXA | Alternate administering location |
+| RXA-28 | `Location.address` | RXA | Administering location address |
+
+---
+
+## Full RSP Segment → FHIR Resource Summary
+
+| V2 Segment | Primary FHIR Resource | Also Produces |
+|---|---|---|
+| MSH | `MessageHeader` | `Organization`, `Endpoint`, `Bundle` (timestamp/id) |
+| QAK | `OperationOutcome` | — |
+| QPD | `Parameters` | — |
+| PID | `Patient` | `RelatedPerson` (mother), `Account` |
+| PD1 | `Patient` (extensions) | `Organization` (primary care), `Practitioner` (PCP) |
+| NK1 | `RelatedPerson` | `Patient` (reference) |
+| ORC | `ServiceRequest` | `Practitioner`, `Organization` |
+| RXA | `Immunization` or `ImmunizationRecommendation` | `Practitioner`, `Organization`, `Location` |
+| RXR | `Immunization` (route/site) | — |
+| OBX | `Observation` | `Immunization` (extensions), `ImmunizationRecommendation` (forecast), `Practitioner`, `Organization` |
+| EVN | — | `Practitioner` (EVN-5), `Location` (EVN-7) |
+| PV1 | `Encounter` | `Location`, `Practitioner` |
+| OBR | `ServiceRequest` | — |
+| DSC | *(continuation)* | — |

--- a/src/main/java/gov/cdc/izgateway/xform/endpoints/fhir/FhirController.java
+++ b/src/main/java/gov/cdc/izgateway/xform/endpoints/fhir/FhirController.java
@@ -779,7 +779,11 @@ public class FhirController {
         
         // Update the bundle type to searchset from message.
         bundle.setType(BundleType.SEARCHSET);
-        String requested = StringUtils.substringAfterLast(req.getRequestURI(), "/");
+        String uri = req.getRequestURI();
+        if (uri.endsWith("/_search")) {
+            uri = StringUtils.substringBeforeLast(uri, "/_search");
+        }
+        String requested = StringUtils.substringAfterLast(uri, "/");
         if ("$match".equals(requested)) {
             requested = PATIENT;
         }

--- a/src/main/java/gov/cdc/izgateway/xform/endpoints/fhir/FhirController.java
+++ b/src/main/java/gov/cdc/izgateway/xform/endpoints/fhir/FhirController.java
@@ -53,6 +53,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -314,6 +315,20 @@ public class FhirController {
         HttpServletRequest req
     ) throws FaultException, HL7Exception, UnexpectedException, SecurityFault {
         return processQuery(req, destinationId);
+    }
+
+    @RequestMapping(
+        value = {
+            "/{destinationId}/Immunization",
+            "/{destinationId}/ImmunizationRecommendation",
+            "/{destinationId}/Patient"
+        },
+        method = RequestMethod.POST
+    )
+    public ResponseEntity<Void> iisSearchPostWithoutSuffix(@PathVariable String destinationId) {
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
+            .allow(HttpMethod.GET, HttpMethod.HEAD)
+            .build();
     }
     
     /**

--- a/src/main/java/gov/cdc/izgateway/xform/endpoints/fhir/FhirController.java
+++ b/src/main/java/gov/cdc/izgateway/xform/endpoints/fhir/FhirController.java
@@ -2,6 +2,7 @@ package gov.cdc.izgateway.xform.endpoints.fhir;
 
 import gov.cdc.izgateway.security.AccessControlRegistry;
 import gov.cdc.izgw.v2tofhir.converter.MessageParser;
+import gov.cdc.izgw.v2tofhir.converter.Parser;
 import gov.cdc.izgw.v2tofhir.datatype.HumanNameParser;
 import gov.cdc.izgw.v2tofhir.segment.PIDParser;
 import gov.cdc.izgw.v2tofhir.utils.QBPUtils;
@@ -21,6 +22,7 @@ import java.util.ServiceConfigurationError;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.hl7.fhir.r4.model.Address;
 import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.Bundle;
@@ -54,6 +56,7 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -216,16 +219,11 @@ public class FhirController {
         description = "An internal error occured while processing the request",
         content = {@Content}
     )
-    @RequestMapping(
+    @GetMapping(
     	value = { 
             "/{destinationId}/Immunization", 
             "/{destinationId}/ImmunizationRecommendation",
             "/{destinationId}/Patient"
-        },
-        method = { 
-            RequestMethod.GET,    // Typical web based query 
-            RequestMethod.POST, // Safer because POST parameters don't wind up in access logs
-            RequestMethod.HEAD    // Used with SMART and other auth mechanisms.
         },
         produces = {
             "application/fhir+xml", 
@@ -242,20 +240,88 @@ public class FhirController {
         HttpServletRequest req
     ) throws FaultException, HL7Exception, UnexpectedException, SecurityFault {
     	String summary = req.getParameter("_summary");
-    	String count = req.getParameter("_count");
     	if (Arrays.asList("summary", "count").contains(summary)) {
-    		return connectionTest(count);
+    		return connectionTest();
     	}
+        return processQuery(req, destinationId);
+    }
+
+    /**
+     * FHIR R4-conformant POST search via the {@code /_search} suffix.
+     * Accepts search parameters as an {@code application/x-www-form-urlencoded} body,
+     * which prevents patient demographics from appearing in server access logs.
+     * Equivalent to a GET search on the base resource URL.
+     *
+     * @param destinationId    The destination for the FHIR Request.  This takes the place of the
+     * destinationId element shown below in Soap Messages.
+     *
+    * <pre>{@code
+    * <HubRequestHeader xmlns="urn:cdc:iisb:hub:2014">
+    *   <DestinationId>dev</DestinationId>
+    * </HubRequestHeader>
+    * }</pre>
+     *
+     * @param req    The HttpServletRequest to get the request parameters from.
+     * @return    A FHIR Bundle containing the search results, or an OperationOutcome resource if there
+     * was an exception, fault or error processing the message.
+     * @throws FaultException When a SoapFault is reported.
+     * @throws HL7Exception When a message cannot be parsed.
+     * @throws UnexpectedException When something goes wrong that shouldn't have
+     * @throws SecurityFault When a security fault occurs
+     */
+    @Operation(
+        summary = "Request an Immunization History or Immunization Recommendation via FHIR POST search",
+        description = "FHIR R4-conformant POST search using the /_search suffix"
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "The request completed normally",
+        content = {
+            @Content(mediaType = "application/json"),
+            @Content(mediaType = "application/xml"),
+            @Content(mediaType = "application/yml")
+        }
+    )
+    @ApiResponse(
+        responseCode = "400",
+        description = "An error occured while processing the request",
+        content = {@Content}
+    )
+    @ApiResponse(
+        responseCode = "500",
+        description = "An internal error occured while processing the request",
+        content = {@Content}
+    )
+    @RequestMapping(
+    	value = { 
+            "/{destinationId}/Immunization/_search",
+            "/{destinationId}/ImmunizationRecommendation/_search",
+            "/{destinationId}/Patient/_search"
+        },
+        method = { RequestMethod.POST, RequestMethod.HEAD },
+        produces = {
+            "application/fhir+xml", 
+            "application/fhir+json", 
+            "application/fhir+yaml",
+            "application/xml",
+            "application/json", 
+            "application/yaml",
+            "text/xml"
+        }
+    )
+    public ResponseEntity<Bundle> iisSearchPost(
+        @PathVariable String destinationId,
+        HttpServletRequest req
+    ) throws FaultException, HL7Exception, UnexpectedException, SecurityFault {
         return processQuery(req, destinationId);
     }
     
     /**
      * This exists to allow query connector to validate authentication
      * parameters when connecting via /Patients?_summary=count&_count=1
-     * @param count	Not used
      * @return	A SearchSet Bundle reporting 100 patients available.
      */
-    private ResponseEntity<Bundle> connectionTest(String count) {
+    private ResponseEntity<Bundle> connectionTest() {
 		Bundle b = new Bundle();
 		b.setId(new IdType(b.fhirType() + "/" + ULID.random()));
 		b.setType(BundleType.SEARCHSET);
@@ -477,7 +543,7 @@ public class FhirController {
                 TokenParam t = new TokenParam();
                 t.setSystem(identifier.getSystem());
                 t.setValue(identifier.getValue());
-                wrapper.addParameter(Patient.SP_IDENTIFIER, t.getValueAsQueryToken(null));
+                wrapper.addParameter(Patient.SP_IDENTIFIER, t.getValueAsQueryToken());
             }
         }
         setNameParameters(wrapper, patient);
@@ -517,7 +583,7 @@ public class FhirController {
         if (patient.hasBirthDate()) {
             DateParam birthDate = new DateParam();
             birthDate.setValue(patient.getBirthDate());
-            String value = StringUtils.substringBefore(birthDate.getValueAsQueryToken(null), "T");
+            String value = StringUtils.substringBefore(birthDate.getValueAsQueryToken(), "T");
             wrapper.addParameter(Patient.SP_BIRTHDATE, value);
         }
         if (patient.hasMultipleBirth()) {
@@ -580,7 +646,7 @@ public class FhirController {
         HttpServletRequest req, 
         String destinationId
     ) throws FaultException, HL7Exception, UnexpectedException, SecurityFault {
-        String queryType = StringUtils.contains(req.getRequestURI(), "ImmunizationRecommendation") ? IzQuery.RECOMMENDATION : IzQuery.HISTORY;
+        String queryType = Strings.CS.contains(req.getRequestURI(), "ImmunizationRecommendation") ? IzQuery.RECOMMENDATION : IzQuery.HISTORY;
         
         // Create the request and set the destination
         SubmitSingleMessageRequest request = new SubmitSingleMessageRequest();
@@ -599,7 +665,7 @@ public class FhirController {
             
             setMSHValues(qbp);
             
-            boolean isPatient = StringUtils.contains(req.getRequestURI(), "/Patient");
+            boolean isPatient = Strings.CS.contains(req.getRequestURI(), "/Patient");
 
     		@SuppressWarnings("unused")
     		IzQuery query = setQueryParameters(req, qbp, isPatient);
@@ -736,7 +802,7 @@ public class FhirController {
     
     private void removeInfrastructureCreatedResources(List<Resource> resources, List<Include> includes, List<Include> revIncludes,
             Iterator<BundleEntryComponent> it, Resource r) {
-        if (r != null && r.getUserData(MessageParser.SOURCE) != null) {
+        if (r != null && r.getUserData(Parser.SOURCE) != null) {
             // Some DatatypeConverter and MessageParser created resources have limited utility.  
             // What we should we do with those depends on what resources the
             // user asks to include.  These infrastructure crafted resources can be white-listed
@@ -749,7 +815,7 @@ public class FhirController {
             // _include=Resource:source:Organization
             // MessageParser created DocumentReference/Provenance
             // _include=Resource:source:DocumentReference
-            String source = r.getUserData(MessageParser.SOURCE).toString();
+            String source = r.getUserData(Parser.SOURCE).toString();
             if (
                 // ANY Source requested
                 // DatatypeConverter created resources including Organization, Practitioner, RelatedPerson, and Location
@@ -777,7 +843,7 @@ public class FhirController {
     private boolean matchesSource(List<Include> includes, String target) {
         for (Include include: includes) {
             if ("Resource".equals(include.getParamType()) 
-            	&& MessageParser.SOURCE.equals(include.getParamName())
+            	&& Parser.SOURCE.equals(include.getParamName())
             	&& Arrays.asList("*", target, null).contains(include.getParamTargetType())
             ) {
                 return true;

--- a/src/main/java/gov/cdc/izgateway/xform/endpoints/fhir/FhirController.java
+++ b/src/main/java/gov/cdc/izgateway/xform/endpoints/fhir/FhirController.java
@@ -317,6 +317,16 @@ public class FhirController {
         return processQuery(req, destinationId);
     }
 
+    /**
+     * Rejects {@code POST} on the bare resource URL with {@code 405 Method Not Allowed}.
+     *
+     * <p>In FHIR R4, {@code POST /{type}} is a <em>create</em> operation, not a search.
+     * FHIR-conformant clients must use {@code POST /{type}/_search} for form-encoded
+     * parameter searches, or {@code GET /{type}?params} for query-string searches.</p>
+     *
+     * @param destinationId the destination identifier (unused; required for path matching)
+     * @return 405 response with {@code Allow: GET, HEAD} header
+     */
     @RequestMapping(
         value = {
             "/{destinationId}/Immunization",

--- a/src/test/java/gov/cdc/izgateway/xform/endpoints/fhir/FhirControllerTests.java
+++ b/src/test/java/gov/cdc/izgateway/xform/endpoints/fhir/FhirControllerTests.java
@@ -1,0 +1,53 @@
+package gov.cdc.izgateway.xform.endpoints.fhir;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import gov.cdc.izgateway.security.AccessControlRegistry;
+import gov.cdc.izgateway.xform.endpoints.hub.HubController;
+
+class FhirControllerTests {
+
+    @Test
+    void postWithoutSearchReturnsMethodNotAllowed() {
+        FhirController controller = new FhirController(
+            mock(HubController.class),
+            new FhirController.FhirConfiguration(),
+            mock(AccessControlRegistry.class)
+        );
+
+        ResponseEntity<Void> response = controller.iisSearchPostWithoutSuffix("dev");
+
+        assertEquals(HttpStatus.METHOD_NOT_ALLOWED, response.getStatusCode());
+        assertEquals(Set.of(HttpMethod.GET, HttpMethod.HEAD), response.getHeaders().getAllow());
+    }
+
+    @Test
+    void postWithoutSearchIsExplicitlyMapped() throws NoSuchMethodException {
+        RequestMapping mapping = FhirController.class
+            .getMethod("iisSearchPostWithoutSuffix", String.class)
+            .getAnnotation(RequestMapping.class);
+
+        assertNotNull(mapping);
+        assertArrayEquals(new RequestMethod[] { RequestMethod.POST }, mapping.method());
+        assertArrayEquals(
+            new String[] {
+                "/{destinationId}/Immunization",
+                "/{destinationId}/ImmunizationRecommendation",
+                "/{destinationId}/Patient"
+            },
+            mapping.value()
+        );
+    }
+}

--- a/testing/scripts/TS_Integration_Test.postman_collection.json
+++ b/testing/scripts/TS_Integration_Test.postman_collection.json
@@ -638,7 +638,7 @@
                   ]
                 },
                 "url": {
-                  "raw": "{{protocol}}://{{host}}:{{port}}/fhir/dev/Immunization",
+                  "raw": "{{protocol}}://{{host}}:{{port}}/fhir/dev/Immunization/_search",
                   "protocol": "{{protocol}}",
                   "host": [
                     "{{host}}"
@@ -647,7 +647,81 @@
                   "path": [
                     "fhir",
                     "dev",
-                    "Immunization"
+                    "Immunization",
+                    "_search"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "TS_TC_07a FHIR GET Query Returns Data",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "let response = pm.response.json();",
+                      "pm.test(\"verify type is Bundle\", function() {",
+                      "    pm.expect(response.resourceType).to.equal(\"Bundle\");",
+                      "});",
+                      "",
+                      "pm.test(\"Verify Entry length is 4\", function() {",
+                      "    pm.expect(response.entry.length).to.equal(4);",
+                      "});",
+                      "",
+                      "pm.test(\"Verify Immunization Code\", function() {",
+                      "    pm.expect(response.entry[3].resource.resourceType).to.equal(\"Immunization\");",
+                      "});",
+                      "",
+                      "pm.test(\"Verify Vaccine Code\", function() {",
+                      "    pm.expect(response.entry[3].resource.vaccineCode.coding[0].code).to.equal(\"208\");",
+                      "});",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "",
+                    "value": "",
+                    "type": "text",
+                    "disabled": true
+                  }
+                ],
+                "url": {
+                  "raw": "{{protocol}}://{{host}}:{{port}}/fhir/dev/Immunization?patient.given={{fhirPatientGiven}}&patient.family={{fhirPatientFamily}}&patient.birthdate={{fhirPatientDOB}}",
+                  "host": [
+                    "{{host}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "patient.given",
+                      "value": "{{fhirPatientGiven}}",
+                      "disabled": false
+                    },
+                    {
+                      "key": "patient.family",
+                      "value": "{{fhirPatientFamily}}",
+                      "disabled": false
+                    },
+                    {
+                      "key": "patient.birthdate",
+                      "value": "{{fhirPatientDOB}}",
+                      "disabled": false
+                    }
                   ]
                 }
               },
@@ -718,7 +792,7 @@
                   ]
                 },
                 "url": {
-                  "raw": "{{protocol}}://{{host}}:{{port}}/fhir/dev/Immunization",
+                  "raw": "{{protocol}}://{{host}}:{{port}}/fhir/dev/Immunization/_search",
                   "protocol": "{{protocol}}",
                   "host": [
                     "{{host}}"
@@ -727,11 +801,133 @@
                   "path": [
                     "fhir",
                     "dev",
-                    "Immunization"
+                    "Immunization",
+                    "_search"
                   ]
                 }
               },
               "response": []
+            },
+            {
+              "name": "TS_TC_08a FHIR GET Query Returns No Data",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "let response = pm.response.json();",
+                      "pm.test(\"verify type is Bundle\", function() {",
+                      "    pm.expect(response.resourceType).to.equal(\"Bundle\");",
+                      "});",
+                      "",
+                      "pm.test(\"Verify Entry length is 2\", function() {",
+                      "    pm.expect(response.entry.length).to.equal(2);",
+                      "});",
+                      "",
+                      "pm.test(\"Verify NF is returned indicating no data found\", function() {",
+                      "    pm.expect(response.entry[1].resource.issue[0].details.coding[0].code).to.equal(\"NF\");",
+                      "});",
+                      "",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {}
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "",
+                    "value": "",
+                    "type": "text",
+                    "disabled": true
+                  }
+                ],
+                "url": {
+                  "raw": "{{protocol}}://{{host}}:{{port}}/fhir/dev/Immunization?patient.given={{fhirNoDataPatientGiven}}&patient.family={{fhirNoDataPatientFamily}}&patient.birthdate={{fhirNoDataPatientDOB}}",
+                  "host": [
+                    "{{host}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "patient.given",
+                      "value": "{{fhirNoDataPatientGiven}}",
+                      "disabled": false
+                    },
+                    {
+                      "key": "patient.family",
+                      "value": "{{fhirNoDataPatientFamily}}",
+                      "disabled": false
+                    },
+                    {
+                      "key": "patient.birthdate",
+                      "value": "{{fhirNoDataPatientDOB}}",
+                      "disabled": false
+                    }
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "TS_TC_09 FHIR POST without _search Returns 405",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "urlencoded",
+                  "urlencoded": [
+                    {
+                      "key": "patient.given",
+                      "value": "{{fhirPatientGiven}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "patient.family",
+                      "value": "{{fhirPatientFamily}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "patient.birthdate",
+                      "value": "{{fhirPatientDOB}}",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{protocol}}://{{host}}:{{port}}/fhir/dev/Immunization",
+                  "host": [
+                    "{{host}}"
+                  ],
+                  "path": [
+                    "fhir",
+                    "dev",
+                    "Immunization"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 405 - POST without /_search is not a valid FHIR search\", function () {",
+                      "    pm.response.to.have.status(405);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
             }
           ],
           "auth": {
@@ -14667,7 +14863,7 @@
                   ]
                 },
                 "url": {
-                  "raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/fhir/dev/Immunization",
+                  "raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/fhir/dev/Immunization/_search",
                   "protocol": "{{no_cert_protocol}}",
                   "host": [
                     "{{no_cert_host}}"
@@ -14676,7 +14872,77 @@
                   "path": [
                     "fhir",
                     "dev",
-                    "Immunization"
+                    "Immunization",
+                    "_search"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "TS_TC_07a FHIR GET Query Returns Data with JWT",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "let response = pm.response.json();",
+                      "pm.test(\"verify type is Bundle\", function() {",
+                      "    pm.expect(response.resourceType).to.equal(\"Bundle\");",
+                      "});",
+                      "",
+                      "pm.test(\"Verify Entry length is 4\", function() {",
+                      "    pm.expect(response.entry.length).to.equal(4);",
+                      "});",
+                      "",
+                      "pm.test(\"Verify Immunization Code\", function() {",
+                      "    pm.expect(response.entry[3].resource.resourceType).to.equal(\"Immunization\");",
+                      "});",
+                      "",
+                      "pm.test(\"Verify Vaccine Code\", function() {",
+                      "    pm.expect(response.entry[3].resource.vaccineCode.coding[0].code).to.equal(\"208\");",
+                      "});",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "x-xform-organization",
+                    "value": "0d15449b-fb08-4013-8985-20c148b353fe",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/fhir/dev/Immunization?patient.given={{fhirPatientGiven}}&patient.family={{fhirPatientFamily}}&patient.birthdate={{fhirPatientDOB}}",
+                  "host": [
+                    "{{host}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "patient.given",
+                      "value": "{{fhirPatientGiven}}",
+                      "disabled": false
+                    },
+                    {
+                      "key": "patient.family",
+                      "value": "{{fhirPatientFamily}}",
+                      "disabled": false
+                    },
+                    {
+                      "key": "patient.birthdate",
+                      "value": "{{fhirPatientDOB}}",
+                      "disabled": false
+                    }
                   ]
                 }
               },
@@ -14743,7 +15009,7 @@
                   ]
                 },
                 "url": {
-                  "raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/fhir/dev/Immunization",
+                  "raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/fhir/dev/Immunization/_search",
                   "protocol": "{{no_cert_protocol}}",
                   "host": [
                     "{{no_cert_host}}"
@@ -14752,11 +15018,129 @@
                   "path": [
                     "fhir",
                     "dev",
-                    "Immunization"
+                    "Immunization",
+                    "_search"
                   ]
                 }
               },
               "response": []
+            },
+            {
+              "name": "TS_TC_08a FHIR GET Query Returns No Data with JWT",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "let response = pm.response.json();",
+                      "pm.test(\"verify type is Bundle\", function() {",
+                      "    pm.expect(response.resourceType).to.equal(\"Bundle\");",
+                      "});",
+                      "",
+                      "pm.test(\"Verify Entry length is 2\", function() {",
+                      "    pm.expect(response.entry.length).to.equal(2);",
+                      "});",
+                      "",
+                      "pm.test(\"Verify NF is returned indicating no data found\", function() {",
+                      "    pm.expect(response.entry[1].resource.issue[0].details.coding[0].code).to.equal(\"NF\");",
+                      "});",
+                      "",
+                      ""
+                    ],
+                    "type": "text/javascript",
+                    "packages": {}
+                  }
+                }
+              ],
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "x-xform-organization",
+                    "value": "0d15449b-fb08-4013-8985-20c148b353fe",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/fhir/dev/Immunization?patient.given={{fhirNoDataPatientGiven}}&patient.family={{fhirNoDataPatientFamily}}&patient.birthdate={{fhirNoDataPatientDOB}}",
+                  "host": [
+                    "{{host}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "patient.given",
+                      "value": "{{fhirNoDataPatientGiven}}",
+                      "disabled": false
+                    },
+                    {
+                      "key": "patient.family",
+                      "value": "{{fhirNoDataPatientFamily}}",
+                      "disabled": false
+                    },
+                    {
+                      "key": "patient.birthdate",
+                      "value": "{{fhirNoDataPatientDOB}}",
+                      "disabled": false
+                    }
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "TS_TC_09 FHIR POST without _search Returns 405",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "urlencoded",
+                  "urlencoded": [
+                    {
+                      "key": "patient.given",
+                      "value": "{{fhirPatientGiven}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "patient.family",
+                      "value": "{{fhirPatientFamily}}",
+                      "type": "text"
+                    },
+                    {
+                      "key": "patient.birthdate",
+                      "value": "{{fhirPatientDOB}}",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{protocol}}://{{host}}:{{port}}/fhir/dev/Immunization",
+                  "host": [
+                    "{{host}}"
+                  ],
+                  "path": [
+                    "fhir",
+                    "dev",
+                    "Immunization"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 405 - POST without /_search is not a valid FHIR search\", function () {",
+                      "    pm.response.to.have.status(405);",
+                      "});"
+                    ]
+                  }
+                }
+              ]
             }
           ]
         },

--- a/testing/scripts/TS_Integration_Test.postman_collection.json
+++ b/testing/scripts/TS_Integration_Test.postman_collection.json
@@ -580,24 +580,20 @@
                       "pm.test(\"Status code is 200\", function () {",
                       "    pm.response.to.have.status(200);",
                       "});",
-                      "",
                       "let response = pm.response.json();",
                       "pm.test(\"verify type is Bundle\", function() {",
                       "    pm.expect(response.resourceType).to.equal(\"Bundle\");",
                       "});",
-                      "",
-                      "pm.test(\"Verify Entry length is 4\", function() {",
-                      "    pm.expect(response.entry.length).to.equal(4);",
+                      "pm.test(\"Verify at least one entry is returned\", function() {",
+                      "    pm.expect(response.entry.length).to.be.at.least(1);",
                       "});",
-                      "",
-                      "pm.test(\"Verify Immunization Code\", function() {",
-                      "    pm.expect(response.entry[3].resource.resourceType).to.equal(\"Immunization\");",
+                      "let immunization = response.entry.find(e => e.resource && e.resource.resourceType === \"Immunization\");",
+                      "pm.test(\"Verify Immunization is present\", function() {",
+                      "    pm.expect(immunization).to.not.be.undefined;",
                       "});",
-                      "",
                       "pm.test(\"Verify Vaccine Code\", function() {",
-                      "    pm.expect(response.entry[3].resource.vaccineCode.coding[0].code).to.equal(\"208\");",
-                      "});",
-                      ""
+                      "    pm.expect(immunization.resource.vaccineCode.coding[0].code).to.equal(\"208\");",
+                      "});"
                     ],
                     "type": "text/javascript",
                     "packages": {}
@@ -664,24 +660,20 @@
                       "pm.test(\"Status code is 200\", function () {",
                       "    pm.response.to.have.status(200);",
                       "});",
-                      "",
                       "let response = pm.response.json();",
                       "pm.test(\"verify type is Bundle\", function() {",
                       "    pm.expect(response.resourceType).to.equal(\"Bundle\");",
                       "});",
-                      "",
-                      "pm.test(\"Verify Entry length is 4\", function() {",
-                      "    pm.expect(response.entry.length).to.equal(4);",
+                      "pm.test(\"Verify at least one entry is returned\", function() {",
+                      "    pm.expect(response.entry.length).to.be.at.least(1);",
                       "});",
-                      "",
-                      "pm.test(\"Verify Immunization Code\", function() {",
-                      "    pm.expect(response.entry[3].resource.resourceType).to.equal(\"Immunization\");",
+                      "let immunization = response.entry.find(e => e.resource && e.resource.resourceType === \"Immunization\");",
+                      "pm.test(\"Verify Immunization is present\", function() {",
+                      "    pm.expect(immunization).to.not.be.undefined;",
                       "});",
-                      "",
                       "pm.test(\"Verify Vaccine Code\", function() {",
-                      "    pm.expect(response.entry[3].resource.vaccineCode.coding[0].code).to.equal(\"208\");",
-                      "});",
-                      ""
+                      "    pm.expect(immunization.resource.vaccineCode.coding[0].code).to.equal(\"208\");",
+                      "});"
                     ],
                     "type": "text/javascript",
                     "packages": {}
@@ -703,8 +695,15 @@
                 ],
                 "url": {
                   "raw": "{{protocol}}://{{host}}:{{port}}/fhir/dev/Immunization?patient.given={{fhirPatientGiven}}&patient.family={{fhirPatientFamily}}&patient.birthdate={{fhirPatientDOB}}",
+                  "protocol": "{{protocol}}",
                   "host": [
                     "{{host}}"
+                  ],
+                  "port": "{{port}}",
+                  "path": [
+                    "fhir",
+                    "dev",
+                    "Immunization"
                   ],
                   "query": [
                     {
@@ -854,8 +853,15 @@
                 ],
                 "url": {
                   "raw": "{{protocol}}://{{host}}:{{port}}/fhir/dev/Immunization?patient.given={{fhirNoDataPatientGiven}}&patient.family={{fhirNoDataPatientFamily}}&patient.birthdate={{fhirNoDataPatientDOB}}",
+                  "protocol": "{{protocol}}",
                   "host": [
                     "{{host}}"
+                  ],
+                  "port": "{{port}}",
+                  "path": [
+                    "fhir",
+                    "dev",
+                    "Immunization"
                   ],
                   "query": [
                     {
@@ -905,9 +911,11 @@
                 },
                 "url": {
                   "raw": "{{protocol}}://{{host}}:{{port}}/fhir/dev/Immunization",
+                  "protocol": "{{protocol}}",
                   "host": [
                     "{{host}}"
                   ],
+                  "port": "{{port}}",
                   "path": [
                     "fhir",
                     "dev",
@@ -14809,24 +14817,20 @@
                       "pm.test(\"Status code is 200\", function () {",
                       "    pm.response.to.have.status(200);",
                       "});",
-                      "",
                       "let response = pm.response.json();",
                       "pm.test(\"verify type is Bundle\", function() {",
                       "    pm.expect(response.resourceType).to.equal(\"Bundle\");",
                       "});",
-                      "",
-                      "pm.test(\"Verify Entry length is 4\", function() {",
-                      "    pm.expect(response.entry.length).to.equal(4);",
+                      "pm.test(\"Verify at least one entry is returned\", function() {",
+                      "    pm.expect(response.entry.length).to.be.at.least(1);",
                       "});",
-                      "",
-                      "pm.test(\"Verify Immunization Code\", function() {",
-                      "    pm.expect(response.entry[3].resource.resourceType).to.equal(\"Immunization\");",
+                      "let immunization = response.entry.find(e => e.resource && e.resource.resourceType === \"Immunization\");",
+                      "pm.test(\"Verify Immunization is present\", function() {",
+                      "    pm.expect(immunization).to.not.be.undefined;",
                       "});",
-                      "",
                       "pm.test(\"Verify Vaccine Code\", function() {",
-                      "    pm.expect(response.entry[3].resource.vaccineCode.coding[0].code).to.equal(\"208\");",
-                      "});",
-                      ""
+                      "    pm.expect(immunization.resource.vaccineCode.coding[0].code).to.equal(\"208\");",
+                      "});"
                     ],
                     "type": "text/javascript",
                     "packages": {}
@@ -14889,24 +14893,20 @@
                       "pm.test(\"Status code is 200\", function () {",
                       "    pm.response.to.have.status(200);",
                       "});",
-                      "",
                       "let response = pm.response.json();",
                       "pm.test(\"verify type is Bundle\", function() {",
                       "    pm.expect(response.resourceType).to.equal(\"Bundle\");",
                       "});",
-                      "",
-                      "pm.test(\"Verify Entry length is 4\", function() {",
-                      "    pm.expect(response.entry.length).to.equal(4);",
+                      "pm.test(\"Verify at least one entry is returned\", function() {",
+                      "    pm.expect(response.entry.length).to.be.at.least(1);",
                       "});",
-                      "",
-                      "pm.test(\"Verify Immunization Code\", function() {",
-                      "    pm.expect(response.entry[3].resource.resourceType).to.equal(\"Immunization\");",
+                      "let immunization = response.entry.find(e => e.resource && e.resource.resourceType === \"Immunization\");",
+                      "pm.test(\"Verify Immunization is present\", function() {",
+                      "    pm.expect(immunization).to.not.be.undefined;",
                       "});",
-                      "",
                       "pm.test(\"Verify Vaccine Code\", function() {",
-                      "    pm.expect(response.entry[3].resource.vaccineCode.coding[0].code).to.equal(\"208\");",
-                      "});",
-                      ""
+                      "    pm.expect(immunization.resource.vaccineCode.coding[0].code).to.equal(\"208\");",
+                      "});"
                     ],
                     "type": "text/javascript",
                     "packages": {}
@@ -14924,8 +14924,15 @@
                 ],
                 "url": {
                   "raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/fhir/dev/Immunization?patient.given={{fhirPatientGiven}}&patient.family={{fhirPatientFamily}}&patient.birthdate={{fhirPatientDOB}}",
+                  "protocol": "{{no_cert_protocol}}",
                   "host": [
-                    "{{host}}"
+                    "{{no_cert_host}}"
+                  ],
+                  "port": "{{no_cert_port}}",
+                  "path": [
+                    "fhir",
+                    "dev",
+                    "Immunization"
                   ],
                   "query": [
                     {
@@ -15067,8 +15074,15 @@
                 ],
                 "url": {
                   "raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/fhir/dev/Immunization?patient.given={{fhirNoDataPatientGiven}}&patient.family={{fhirNoDataPatientFamily}}&patient.birthdate={{fhirNoDataPatientDOB}}",
+                  "protocol": "{{no_cert_protocol}}",
                   "host": [
-                    "{{host}}"
+                    "{{no_cert_host}}"
+                  ],
+                  "port": "{{no_cert_port}}",
+                  "path": [
+                    "fhir",
+                    "dev",
+                    "Immunization"
                   ],
                   "query": [
                     {
@@ -15118,9 +15132,11 @@
                 },
                 "url": {
                   "raw": "{{protocol}}://{{host}}:{{port}}/fhir/dev/Immunization",
+                  "protocol": "{{protocol}}",
                   "host": [
                     "{{host}}"
                   ],
+                  "port": "{{port}}",
                   "path": [
                     "fhir",
                     "dev",

--- a/testing/scripts/TS_Integration_Test.postman_collection.json
+++ b/testing/scripts/TS_Integration_Test.postman_collection.json
@@ -15131,12 +15131,12 @@
                   ]
                 },
                 "url": {
-                  "raw": "{{protocol}}://{{host}}:{{port}}/fhir/dev/Immunization",
-                  "protocol": "{{protocol}}",
+                  "raw": "{{no_cert_protocol}}://{{no_cert_host}}:{{no_cert_port}}/fhir/dev/Immunization",
+                  "protocol": "{{no_cert_protocol}}",
                   "host": [
-                    "{{host}}"
+                    "{{no_cert_host}}"
                   ],
-                  "port": "{{port}}",
+                  "port": "{{no_cert_port}}",
                   "path": [
                     "fhir",
                     "dev",


### PR DESCRIPTION
## Summary

Fixes a FHIR R4 conformance bug where \POST /{type}\ was being accepted as a search request. In FHIR R4, \POST /{type}\ means **create** — search via POST must use \POST /{type}/\_search\.

## Changes

### FhirController.java
- Split single \@RequestMapping\ into two methods:
  - \iisQuery\: \GET\ (+ implicit HEAD) on \/{destinationId}/{type}\ — standard FHIR search
  - \iisSearchPost\: \POST\ + \HEAD\ on \/{destinationId}/{type}/\_search\ — POST-based FHIR search per spec
  - \POST /{type}\ without \/\_search\ now correctly returns **405 Method Not Allowed**

### docs/fhir/ (new)
Public-facing API documentation for the FHIR facade:
- \index.md\ — architecture, resource table, ID encoding conventions
- \fhir-api.md\ — full API reference including \\_include\ use cases, error handling, POST search
- \fhir-to-qbp.md\ — FHIR parameter to HL7 QPD field mapping table
- \rsp-to-fhir.md\ — RSP_K11 segment to FHIR resource mapping tables

### Postman Tests
- TC_07/TC_08 updated to use \POST /\_search\
- Added TC_07a/TC_08a: GET search with query parameters
- Added TC_09: asserts \POST /Immunization\ (without \/\_search\) returns 405

## References
Closes IGDD-2972