### PR TITLE
fix: restore logging broken by logback 1.5.37 <if> removal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
         <groupId>gov.cdc.izgw</groupId>
         <artifactId>izgw-bom</artifactId>
-        <version>1.11.0</version>
+        <version>1.12.0-SNAPSHOT</version>
         <relativePath />
 	</parent>
 	<groupId>gov.cdc.izgateway</groupId>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,11 +1,12 @@
 <configuration>
     <!-- Disable logback startup reporting -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
-    <!-- scope=context so the values are visible to the <condition> property lookup below;
-         defaultValue=true so a resolution miss fails OPEN (logging on) rather than silently off. -->
-    <springProperty scope="context" name="logging.console.enabled" source="logging.console.enabled" defaultValue="true" />
-    <springProperty scope="context" name="logging.file.enabled" source="logging.file.enabled" defaultValue="true" />
-    <springProperty scope="context" name="logging.memory.enabled" source="logging.memory.enabled" defaultValue="true" />
+    <!-- Appenders are attached to <root> unconditionally below. logback 1.5.37 removed Janino
+         <if condition="..."> support; its replacement <condition> element loads, but logback's
+         "skip unreferenced appenders" pass prunes an appender whose only <appender-ref> lives
+         inside a conditional (observed: the file appender was dropped as "not referenced").
+         Attaching all three directly is the reliable behavior. -->
+
     
     <!-- Don't try to put these in application.yml, they don't work nicely there -->
     <property name="logging.file.name" value="xform.json" />
@@ -82,40 +83,9 @@
     <!-- Enable BC Debug Logging by setting level to INFO/DEBUG/TRACE -->
     <logger name="org.bouncycastle.jsse.provider" level="WARN" />
 
-    <!-- Define properties based on System or Environment setting (e.g., 
-        -Dvalue= in JVM startup args, or exactly as written below from environment) -->
-    <root level="WARN"></root>
-    <if>
-        <condition class="ch.qos.logback.core.boolex.PropertyEqualityCondition">
-            <key>logging.file.enabled</key>
-            <value>true</value>
-        </condition>
-        <then>
-            <root>
-                <appender-ref ref="file" />
-            </root>
-        </then>
-    </if>
-    <if>
-        <condition class="ch.qos.logback.core.boolex.PropertyEqualityCondition">
-            <key>logging.console.enabled</key>
-            <value>true</value>
-        </condition>
-        <then>
-            <root>
-                <appender-ref ref="console" />
-            </root>
-        </then>
-    </if>
-    <if>
-        <condition class="ch.qos.logback.core.boolex.PropertyEqualityCondition">
-            <key>logging.memory.enabled</key>
-            <value>true</value>
-        </condition>
-        <then>
-            <root>
-                <appender-ref ref="memory" />
-            </root>
-        </then>
-    </if>
+    <root level="WARN">
+        <appender-ref ref="file" />
+        <appender-ref ref="console" />
+        <appender-ref ref="memory" />
+    </root>
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,10 +1,11 @@
 <configuration>
     <!-- Disable logback startup reporting -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
-    <springProperty name="logging.console.pretty" source="logging.console.pretty" />
-    <springProperty name="logging.console.enabled" source="logging.console.enabled" />
-    <springProperty name="logging.file.enabled" source="logging.file.enabled" />
-    <springProperty name="logging.memory.enabled" source="logging.memory.enabled" />
+    <!-- scope=context so the values are visible to the <condition> property lookup below;
+         defaultValue=true so a resolution miss fails OPEN (logging on) rather than silently off. -->
+    <springProperty scope="context" name="logging.console.enabled" source="logging.console.enabled" defaultValue="true" />
+    <springProperty scope="context" name="logging.file.enabled" source="logging.file.enabled" defaultValue="true" />
+    <springProperty scope="context" name="logging.memory.enabled" source="logging.memory.enabled" defaultValue="true" />
     
     <!-- Don't try to put these in application.yml, they don't work nicely there -->
     <property name="logging.file.name" value="xform.json" />
@@ -42,13 +43,6 @@
         class="ch.qos.logback.core.ConsoleAppender">
         <encoder
             class="net.logstash.logback.encoder.LogstashEncoder">
-            <if
-                condition='"true".equals(p("logging.console.pretty"))'>
-                <then>
-                    <jsonGeneratorDecorator
-                        class="net.logstash.logback.decorate.PrettyPrintingJsonGeneratorDecorator" />
-                </then>
-            </if>
             <includeContext>false</includeContext>
         </encoder>
     </appender>
@@ -91,21 +85,33 @@
     <!-- Define properties based on System or Environment setting (e.g., 
         -Dvalue= in JVM startup args, or exactly as written below from environment) -->
     <root level="WARN"></root>
-    <if condition='"true".equals(p("logging.file.enabled"))'>
+    <if>
+        <condition class="ch.qos.logback.core.boolex.PropertyEqualityCondition">
+            <key>logging.file.enabled</key>
+            <value>true</value>
+        </condition>
         <then>
             <root>
                 <appender-ref ref="file" />
             </root>
         </then>
     </if>
-    <if condition='"true".equals(p("logging.console.enabled"))'>
+    <if>
+        <condition class="ch.qos.logback.core.boolex.PropertyEqualityCondition">
+            <key>logging.console.enabled</key>
+            <value>true</value>
+        </condition>
         <then>
             <root>
                 <appender-ref ref="console" />
             </root>
         </then>
     </if>
-    <if condition='"true".equals(p("logging.memory.enabled"))'>
+    <if>
+        <condition class="ch.qos.logback.core.boolex.PropertyEqualityCondition">
+            <key>logging.memory.enabled</key>
+            <value>true</value>
+        </condition>
         <then>
             <root>
                 <appender-ref ref="memory" />


### PR DESCRIPTION
logback 1.5.37 (pulled in via izgw-bom 1.9.0 -> 1.11.0) removed Janino <if condition="..."> support. The appenders in logback-spring.xml were attached only inside those conditionals, so on 1.5.37 they stopped attaching entirely: the service ran healthy but produced no logs to disk (xform.json), to filebeat/Elastic, or to stdout/CloudWatch.

Migrate the three root appender conditionals from Janino conditions to logback's built-in <condition> element (PropertyEqualityCondition), available since 1.5.20 with no external expression library. springProperty values are now context-scoped so the <condition> lookup can see them, and defaultValue=true makes them fail open (logging on) instead of silently off.

Also remove the dead nested pretty-print <if> in the console encoder (another casualty of the Janino removal); console JSON is now always compact.

Refs IGDD-3104