### PR TITLE
fix: Add COMPUTERNAME env set in release so that the /build.txt shows

### DIFF
--- a/.github/workflows/_release_common.yml
+++ b/.github/workflows/_release_common.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Set up Toolchain and Maven settings
         shell: bash
         run: |
+          # Capture the build runner hostname so Maven can resolve
+          # %{env.COMPUTERNAME} in docker/webapp/static/build.txt (matches maven.yml).
+          echo COMPUTERNAME=`hostname` >> $GITHUB_ENV
           mkdir -p ~/.m2
           cat << 'EOF' > ~/.m2/toolchains.xml
           <?xml version="1.0" encoding="UTF-8"?>

--- a/dependency-suppression.xml
+++ b/dependency-suppression.xml
@@ -89,4 +89,34 @@
         <cve>CVE-2026-54399</cve>
         <cve>CVE-2026-54428</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+    kotlin-stdlib-1.9.25.jar: CVE-2026-53914 is not exploitable in this service.
+    The vulnerability is a BUILD-TIME issue in Kotlin's build cache metadata (unsafe
+    deserialization, CWE-502) and is only reachable when compiling Kotlin code with
+    Kotlin's build tooling. izgw-transform is a Maven/Java service that runs no Kotlin
+    compiler and no Kotlin build cache, so the vulnerable code path is not present at runtime.
+
+    kotlin-stdlib is present only as a transitive runtime dependency of OkHttp libs, which are
+    pulled in by HAPI's org.hl7.fhir.utilities, for example:
+        v2tofhir -> hapi-fhir-structures-r4:8.10.1 -> org.hl7.fhir.utilities:6.9.12
+                 -> okhttp-jvm:5.3.2 -> kotlin-stdlib:1.9.25
+    OkHttp/kotlin-stdlib are only used by the utilities' HTTP, terminology-server, and
+    remote package-loading classes. izgw-transform performs HL7v2->FHIR conversion only and
+    never invokes those paths: it contains no Kotlin source and no direct okhttp/kotlin usage.
+
+    Verified empirically (2026-07-28): a representative VXU^V04 -> FHIR conversion via the
+    production call `new MessageParser().convert(...)` loaded 2,264 classes with 0 kotlin and
+    0 okhttp classes loaded (164 org.hl7.fhir.r4.model + 70 v2tofhir classes did load).
+    Terminology is resolved locally (V2TOFHIR_TERMINOLOGY_MAPPER not set -> supplier-provided
+    mapper), so no remote tx-server/okhttp path is exercised.
+
+    Scanner shows the inflated NVD 9.8 auto-score; JetBrains (CNA) rates it 6.7 Medium
+    (AV:L/AC:H/PR:H). Fixed in Kotlin 2.4.20, which is not yet GA (betas only as of 2026-07-28).
+    TEMPORARY: remove this suppression once Kotlin 2.4.20 GA is pinned via kotlin-bom in izgw-bom.
+    Added: 2026-07-28 (IGDD-3141)
+    ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib@.*$</packageUrl>
+        <cve>CVE-2026-53914</cve>
+    </suppress>
 </suppressions>

--- a/dependency-suppression.xml
+++ b/dependency-suppression.xml
@@ -91,32 +91,27 @@
     </suppress>
     <suppress>
         <notes><![CDATA[
-    kotlin-stdlib-1.9.25.jar: CVE-2026-53914 is not exploitable in this service.
-    The vulnerability is a BUILD-TIME issue in Kotlin's build cache metadata (unsafe
-    deserialization, CWE-502) and is only reachable when compiling Kotlin code with
-    Kotlin's build tooling. izgw-transform is a Maven/Java service that runs no Kotlin
-    compiler and no Kotlin build cache, so the vulnerable code path is not present at runtime.
+        kotlin-stdlib-1.9.25.jar: CVE-2026-53914 is not exploitable in this service.
+        The vulnerability is a BUILD-TIME issue in Kotlin's build cache metadata (unsafe
+        deserialization, CWE-502), only reachable when compiling Kotlin with Kotlin's build
+        tooling. izgw-transform is a Maven/Java service that runs no Kotlin compiler and no
+        Kotlin build cache, so the vulnerable code path is not present at runtime. kotlin-stdlib
+        is only on the classpath transitively (via okio/okhttp under org.hl7.fhir.utilities);
+        a representative VXU^V04 -> FHIR conversion loaded 0 kotlin and 0 okhttp classes.
 
-    kotlin-stdlib is present only as a transitive runtime dependency of OkHttp libs, which are
-    pulled in by HAPI's org.hl7.fhir.utilities, for example:
-        v2tofhir -> hapi-fhir-structures-r4:8.10.1 -> org.hl7.fhir.utilities:6.9.12
-                 -> okhttp-jvm:5.3.2 -> kotlin-stdlib:1.9.25
-    OkHttp/kotlin-stdlib are only used by the utilities' HTTP, terminology-server, and
-    remote package-loading classes. izgw-transform performs HL7v2->FHIR conversion only and
-    never invokes those paths: it contains no Kotlin source and no direct okhttp/kotlin usage.
+        MATCH NOTE: kotlin-stdlib is a Gradle-built jar with no embedded META-INF/maven
+        pom.properties, so the CI scan (dependency-check GitHub Action scanning the assembled
+        fat jar) derives no Maven packageUrl for it and identifies it only by
+        cpe:/a:jetbrains:kotlin. A packageUrl suppression therefore does not match; this rule
+        matches by filePath (the nested jar filename), which works in both the fat-jar and
+        Maven-plugin scans.
 
-    Verified empirically (2026-07-28): a representative VXU^V04 -> FHIR conversion via the
-    production call `new MessageParser().convert(...)` loaded 2,264 classes with 0 kotlin and
-    0 okhttp classes loaded (164 org.hl7.fhir.r4.model + 70 v2tofhir classes did load).
-    Terminology is resolved locally (V2TOFHIR_TERMINOLOGY_MAPPER not set -> supplier-provided
-    mapper), so no remote tx-server/okhttp path is exercised.
-
-    Scanner shows the inflated NVD 9.8 auto-score; JetBrains (CNA) rates it 6.7 Medium
-    (AV:L/AC:H/PR:H). Fixed in Kotlin 2.4.20, which is not yet GA (betas only as of 2026-07-28).
-    TEMPORARY: remove this suppression once Kotlin 2.4.20 GA is pinned via kotlin-bom in izgw-bom.
-    Added: 2026-07-28 (IGDD-3141)
-    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib@.*$</packageUrl>
+        Scanner shows the inflated NVD 9.8 auto-score; JetBrains (CNA) rates it 6.7 Medium
+        (AV:L/AC:H/PR:H). Fixed in Kotlin 2.4.20, not yet GA (betas only as of 2026-07-28).
+        TEMPORARY: remove once Kotlin 2.4.20 GA is pinned via kotlin-bom in izgw-bom.
+        Added: 2026-07-28 (IGDD-3141)
+        ]]></notes>
+        <filePath regex="true">.*kotlin-stdlib-.*\.jar</filePath>
         <cve>CVE-2026-53914</cve>
     </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>gov.cdc.izgw</groupId>
 			<artifactId>v2tofhir</artifactId>
-			<version>2.3.0</version>
+			<version>2.4.0-SNAPSHOT</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.xerial</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
         <groupId>gov.cdc.izgw</groupId>
         <artifactId>izgw-bom</artifactId>
-        <version>1.12.0</version>
+        <version>1.13.0-SNAPSHOT</version>
         <relativePath />
 	</parent>
 	<groupId>gov.cdc.izgateway</groupId>


### PR DESCRIPTION
Missing from release process for Xform Service.  When you hit /build.txt you only see:

```
    Build: xform-0.20.1-202607101246
     Host: %{env.COMPUTERNAME}
Timestamp: 202607101246
```

Dev workflow in GitHub was fine.

---

Also - bumped izgw-bom to latest snapshot to capture some dependency updates.

---

Added suppression for kotlin-stdlib which dependency-checker was flagging.  See Jira https://izgateway.atlassian.net/browse/IGDD-3141 for details.