### PR TITLE
IGDD-3163 - Do not execute inactive pipelines

### DIFF
--- a/.github/workflows/_release_common.yml
+++ b/.github/workflows/_release_common.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Set up Toolchain and Maven settings
         shell: bash
         run: |
+          # Capture the build runner hostname so Maven can resolve
+          # %{env.COMPUTERNAME} in docker/webapp/static/build.txt (matches maven.yml).
+          echo COMPUTERNAME=`hostname` >> $GITHUB_ENV
           mkdir -p ~/.m2
           cat << 'EOF' > ~/.m2/toolchains.xml
           <?xml version="1.0" encoding="UTF-8"?>

--- a/dependency-suppression.xml
+++ b/dependency-suppression.xml
@@ -89,4 +89,34 @@
         <cve>CVE-2026-54399</cve>
         <cve>CVE-2026-54428</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+    kotlin-stdlib-1.9.25.jar: CVE-2026-53914 is not exploitable in this service.
+    The vulnerability is a BUILD-TIME issue in Kotlin's build cache metadata (unsafe
+    deserialization, CWE-502) and is only reachable when compiling Kotlin code with
+    Kotlin's build tooling. izgw-transform is a Maven/Java service that runs no Kotlin
+    compiler and no Kotlin build cache, so the vulnerable code path is not present at runtime.
+
+    kotlin-stdlib is present only as a transitive runtime dependency of OkHttp libs, which are
+    pulled in by HAPI's org.hl7.fhir.utilities, for example:
+        v2tofhir -> hapi-fhir-structures-r4:8.10.1 -> org.hl7.fhir.utilities:6.9.12
+                 -> okhttp-jvm:5.3.2 -> kotlin-stdlib:1.9.25
+    OkHttp/kotlin-stdlib are only used by the utilities' HTTP, terminology-server, and
+    remote package-loading classes. izgw-transform performs HL7v2->FHIR conversion only and
+    never invokes those paths: it contains no Kotlin source and no direct okhttp/kotlin usage.
+
+    Verified empirically (2026-07-28): a representative VXU^V04 -> FHIR conversion via the
+    production call `new MessageParser().convert(...)` loaded 2,264 classes with 0 kotlin and
+    0 okhttp classes loaded (164 org.hl7.fhir.r4.model + 70 v2tofhir classes did load).
+    Terminology is resolved locally (V2TOFHIR_TERMINOLOGY_MAPPER not set -> supplier-provided
+    mapper), so no remote tx-server/okhttp path is exercised.
+
+    Scanner shows the inflated NVD 9.8 auto-score; JetBrains (CNA) rates it 6.7 Medium
+    (AV:L/AC:H/PR:H). Fixed in Kotlin 2.4.20, which is not yet GA (betas only as of 2026-07-28).
+    TEMPORARY: remove this suppression once Kotlin 2.4.20 GA is pinned via kotlin-bom in izgw-bom.
+    Added: 2026-07-28 (IGDD-3141)
+    ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib@.*$</packageUrl>
+        <cve>CVE-2026-53914</cve>
+    </suppress>
 </suppressions>

--- a/dependency-suppression.xml
+++ b/dependency-suppression.xml
@@ -91,32 +91,27 @@
     </suppress>
     <suppress>
         <notes><![CDATA[
-    kotlin-stdlib-1.9.25.jar: CVE-2026-53914 is not exploitable in this service.
-    The vulnerability is a BUILD-TIME issue in Kotlin's build cache metadata (unsafe
-    deserialization, CWE-502) and is only reachable when compiling Kotlin code with
-    Kotlin's build tooling. izgw-transform is a Maven/Java service that runs no Kotlin
-    compiler and no Kotlin build cache, so the vulnerable code path is not present at runtime.
+        kotlin-stdlib-1.9.25.jar: CVE-2026-53914 is not exploitable in this service.
+        The vulnerability is a BUILD-TIME issue in Kotlin's build cache metadata (unsafe
+        deserialization, CWE-502), only reachable when compiling Kotlin with Kotlin's build
+        tooling. izgw-transform is a Maven/Java service that runs no Kotlin compiler and no
+        Kotlin build cache, so the vulnerable code path is not present at runtime. kotlin-stdlib
+        is only on the classpath transitively (via okio/okhttp under org.hl7.fhir.utilities);
+        a representative VXU^V04 -> FHIR conversion loaded 0 kotlin and 0 okhttp classes.
 
-    kotlin-stdlib is present only as a transitive runtime dependency of OkHttp libs, which are
-    pulled in by HAPI's org.hl7.fhir.utilities, for example:
-        v2tofhir -> hapi-fhir-structures-r4:8.10.1 -> org.hl7.fhir.utilities:6.9.12
-                 -> okhttp-jvm:5.3.2 -> kotlin-stdlib:1.9.25
-    OkHttp/kotlin-stdlib are only used by the utilities' HTTP, terminology-server, and
-    remote package-loading classes. izgw-transform performs HL7v2->FHIR conversion only and
-    never invokes those paths: it contains no Kotlin source and no direct okhttp/kotlin usage.
+        MATCH NOTE: kotlin-stdlib is a Gradle-built jar with no embedded META-INF/maven
+        pom.properties, so the CI scan (dependency-check GitHub Action scanning the assembled
+        fat jar) derives no Maven packageUrl for it and identifies it only by
+        cpe:/a:jetbrains:kotlin. A packageUrl suppression therefore does not match; this rule
+        matches by filePath (the nested jar filename), which works in both the fat-jar and
+        Maven-plugin scans.
 
-    Verified empirically (2026-07-28): a representative VXU^V04 -> FHIR conversion via the
-    production call `new MessageParser().convert(...)` loaded 2,264 classes with 0 kotlin and
-    0 okhttp classes loaded (164 org.hl7.fhir.r4.model + 70 v2tofhir classes did load).
-    Terminology is resolved locally (V2TOFHIR_TERMINOLOGY_MAPPER not set -> supplier-provided
-    mapper), so no remote tx-server/okhttp path is exercised.
-
-    Scanner shows the inflated NVD 9.8 auto-score; JetBrains (CNA) rates it 6.7 Medium
-    (AV:L/AC:H/PR:H). Fixed in Kotlin 2.4.20, which is not yet GA (betas only as of 2026-07-28).
-    TEMPORARY: remove this suppression once Kotlin 2.4.20 GA is pinned via kotlin-bom in izgw-bom.
-    Added: 2026-07-28 (IGDD-3141)
-    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib@.*$</packageUrl>
+        Scanner shows the inflated NVD 9.8 auto-score; JetBrains (CNA) rates it 6.7 Medium
+        (AV:L/AC:H/PR:H). Fixed in Kotlin 2.4.20, not yet GA (betas only as of 2026-07-28).
+        TEMPORARY: remove once Kotlin 2.4.20 GA is pinned via kotlin-bom in izgw-bom.
+        Added: 2026-07-28 (IGDD-3141)
+        ]]></notes>
+        <filePath regex="true">.*kotlin-stdlib-.*\.jar</filePath>
         <cve>CVE-2026-53914</cve>
     </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>gov.cdc.izgw</groupId>
 			<artifactId>v2tofhir</artifactId>
-			<version>2.3.0</version>
+			<version>2.4.0-SNAPSHOT</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.xerial</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
         <groupId>gov.cdc.izgw</groupId>
         <artifactId>izgw-bom</artifactId>
-        <version>1.12.0</version>
+        <version>1.13.0-SNAPSHOT</version>
         <relativePath />
 	</parent>
 	<groupId>gov.cdc.izgateway</groupId>

--- a/src/main/java/gov/cdc/izgateway/xform/services/PipelineService.java
+++ b/src/main/java/gov/cdc/izgateway/xform/services/PipelineService.java
@@ -23,6 +23,7 @@ public class PipelineService extends GenericService<Pipeline>{
                         p -> p.getOrganizationId().equals(organizationId)
                                 && p.getInboundEndpoint().equals(inboundEndpoint)
                                 && p.getOutboundEndpoint().equals(outboundEndpoint)
+                                //&& p.getActive().equals(true)
                 ).findFirst().orElse(null);
     }
 

--- a/src/main/java/gov/cdc/izgateway/xform/services/PipelineService.java
+++ b/src/main/java/gov/cdc/izgateway/xform/services/PipelineService.java
@@ -23,7 +23,7 @@ public class PipelineService extends GenericService<Pipeline>{
                         p -> p.getOrganizationId().equals(organizationId)
                                 && p.getInboundEndpoint().equals(inboundEndpoint)
                                 && p.getOutboundEndpoint().equals(outboundEndpoint)
-                                //&& p.getActive().equals(true)
+                                && Boolean.TRUE.equals(p.getActive())
                 ).findFirst().orElse(null);
     }
 

--- a/src/test/java/gov/cdc/izgateway/xform/services/PipelineServiceTest.java
+++ b/src/test/java/gov/cdc/izgateway/xform/services/PipelineServiceTest.java
@@ -1,0 +1,145 @@
+package gov.cdc.izgateway.xform.services;
+
+import gov.cdc.izgateway.logging.RequestContext;
+import gov.cdc.izgateway.security.IzgPrincipal;
+import gov.cdc.izgateway.xform.camel.constants.EndpointUris;
+import gov.cdc.izgateway.xform.logging.XformRequestContext;
+import gov.cdc.izgateway.xform.model.Pipeline;
+import gov.cdc.izgateway.xform.repository.RepositoryFactory;
+import gov.cdc.izgateway.xform.repository.XformRepository;
+import gov.cdc.izgateway.xform.security.Roles;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PipelineService#getPipelineByOrganizationAndEndpoints}, which is the
+ * lookup used on the message-execution path to resolve which pipeline runs for a given
+ * Organization + Inbound Endpoint + Outbound Endpoint.
+ *
+ * <p>
+ * These tests focus on the requirement that <strong>inactive pipelines must never be executed</strong>:
+ * the lookup must only return a pipeline whose {@code active} flag is {@code Boolean.TRUE}, and must
+ * do so in a null-safe manner (an unset {@code active} is treated as not-active rather than throwing).
+ * </p>
+ */
+@ExtendWith(MockitoExtension.class)
+class PipelineServiceTest {
+
+    @Mock
+    private XformRepository<Pipeline> pipelineRepository;
+
+    @Mock
+    private RepositoryFactory repositoryFactory;
+
+    private PipelineService pipelineService;
+
+    private static final UUID ORG_ID = UUID.randomUUID();
+    private static final String INBOUND = EndpointUris.IZGTS_IISHubService;
+    private static final String OUTBOUND = EndpointUris.IZGHUB_IISHubService;
+
+    @BeforeEach
+    void setUp() {
+        when(repositoryFactory.pipelineRepository()).thenReturn(pipelineRepository);
+        pipelineService = new PipelineService(repositoryFactory);
+
+        // getPipelineByOrganizationAndEndpoints() flows through GenericService.getList(), which
+        // consults RequestContext for access control and emits an API read event. Provide an ADMIN
+        // principal so all entities are accessible, and disable API logging for this internal call.
+        IzgPrincipal admin = new IzgPrincipal() {
+            @Override
+            public String getSerialNumberHex() {
+                return null;
+            }
+        };
+        admin.setName("test-admin");
+        admin.setRoles(new HashSet<>(Set.of(Roles.ADMIN)));
+        RequestContext.setPrincipal(admin);
+        XformRequestContext.disableApiLogging();
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContext.clear();
+        XformRequestContext.clear();
+    }
+
+    private Pipeline pipeline(String inbound, String outbound, Boolean active) {
+        Pipeline pipeline = new Pipeline();
+        pipeline.setId(UUID.randomUUID());
+        pipeline.setPipelineName("pipeline-" + UUID.randomUUID());
+        pipeline.setOrganizationId(ORG_ID);
+        pipeline.setInboundEndpoint(inbound);
+        pipeline.setOutboundEndpoint(outbound);
+        pipeline.setActive(active);
+        pipeline.setPipes(new ArrayList<>());
+        return pipeline;
+    }
+
+    private void givenPipelines(Pipeline... pipelines) {
+        when(pipelineRepository.getEntitySet()).thenReturn(new LinkedHashSet<>(java.util.Arrays.asList(pipelines)));
+    }
+
+    @Test
+    void returnsPipeline_whenMatchingAndActive() {
+        Pipeline active = pipeline(INBOUND, OUTBOUND, true);
+        givenPipelines(active);
+
+        Pipeline result = pipelineService.getPipelineByOrganizationAndEndpoints(ORG_ID, INBOUND, OUTBOUND);
+
+        assertEquals(active.getId(), result.getId());
+    }
+
+    @Test
+    void returnsNull_whenMatchingPipelineIsInactive() {
+        givenPipelines(pipeline(INBOUND, OUTBOUND, false));
+
+        Pipeline result = pipelineService.getPipelineByOrganizationAndEndpoints(ORG_ID, INBOUND, OUTBOUND);
+
+        assertNull(result, "An inactive pipeline must not be resolved for execution");
+    }
+
+    @Test
+    void returnsNull_whenActiveFlagIsNull() {
+        givenPipelines(pipeline(INBOUND, OUTBOUND, null));
+
+        Pipeline result = pipelineService.getPipelineByOrganizationAndEndpoints(ORG_ID, INBOUND, OUTBOUND);
+
+        assertNull(result, "A null active flag must be treated as not-active (null-safe), not throw");
+    }
+
+    @Test
+    void skipsInactiveDuplicate_andReturnsActiveOne() {
+        // Same Organization + Inbound + Outbound on both; the inactive one is listed first to prove
+        // the active filter (not iteration order) determines the result.
+        Pipeline inactive = pipeline(INBOUND, OUTBOUND, false);
+        Pipeline active = pipeline(INBOUND, OUTBOUND, true);
+        givenPipelines(inactive, active);
+
+        Pipeline result = pipelineService.getPipelineByOrganizationAndEndpoints(ORG_ID, INBOUND, OUTBOUND);
+
+        assertEquals(active.getId(), result.getId());
+    }
+
+    @Test
+    void returnsNull_whenEndpointsDoNotMatch() {
+        givenPipelines(pipeline(INBOUND, EndpointUris.IIS_IISService, true));
+
+        Pipeline result = pipelineService.getPipelineByOrganizationAndEndpoints(ORG_ID, INBOUND, OUTBOUND);
+
+        assertNull(result, "A pipeline with non-matching endpoints must not be resolved");
+    }
+}


### PR DESCRIPTION
When data is sent Pipelines are pulled by Organization, Inbound Endpoint and Outbound endpoint.  If there are > 1 the first in the list is taken.  BUT if a pipeline is inactive it is still executed.  This prevents that from happening.