### PR TITLE
IGDD-3169: Honor Accept/_format on FHIR POST /Patient/$match and other FHIR response paths

### DIFF
--- a/src/main/java/gov/cdc/izgateway/xform/endpoints/fhir/FhirController.java
+++ b/src/main/java/gov/cdc/izgateway/xform/endpoints/fhir/FhirController.java
@@ -245,7 +245,7 @@ public class FhirController {
     ) throws FaultException, HL7Exception, UnexpectedException, SecurityFault {
     	String summary = req.getParameter("_summary");
     	if (Arrays.asList("summary", "count").contains(summary)) {
-    		return connectionTest();
+    		return connectionTest(req);
     	}
         return processQuery(req, destinationId);
     }
@@ -347,14 +347,15 @@ public class FhirController {
     /**
      * This exists to allow query connector to validate authentication
      * parameters when connecting via /Patients?_summary=count&_count=1
+     * @param req	The request, used to negotiate the response content type.
      * @return	A SearchSet Bundle reporting 100 patients available.
      */
-    private ResponseEntity<Bundle> connectionTest() {
+    private ResponseEntity<Bundle> connectionTest(HttpServletRequest req) {
 		Bundle b = new Bundle();
 		b.setId(new IdType(b.fhirType() + "/" + ULID.random()));
 		b.setType(BundleType.SEARCHSET);
 		b.setTotal(100);
-		return new ResponseEntity<>(b, HttpStatus.OK);
+		return new ResponseEntity<>(b, ContentUtils.getHeaders(req), HttpStatus.OK);
     }
 
     /**
@@ -423,7 +424,7 @@ public class FhirController {
         try {
             decodedId = FhirIdCodec.decode(id);
         } catch (IllegalFormatCodePointException ex) {
-            return notFound(id);
+            return notFound(req, id);
         }
         String resourceType = StringUtils.substringBetween(req.getRequestURI(), destinationId + "/", "/" + id); 
         
@@ -431,7 +432,7 @@ public class FhirController {
         boolean isPatient = PATIENT.equals(resourceType); 
         int index = isPatient ? 0 : 2;
         if (idParts.length < index + 2) {
-            return notFound(id);
+            return notFound(req, id);
         }
         Identifier ident = new Identifier().setSystem(idParts[index]).setValue(idParts[index + 1]);
         
@@ -441,7 +442,7 @@ public class FhirController {
         Bundle b = res.getBody();
         if (b == null) {
             // Technically this is an error.
-            return notFound(id);
+            return notFound(req, id);
         }
         Resource resource = b.getEntry().stream()
             .map(e -> e.getResource())
@@ -450,7 +451,7 @@ public class FhirController {
             .orElse(null);
         
         if (resource == null) {
-            return notFound(id);
+            return notFound(req, id);
         }
         return new ResponseEntity<>(resource, res.getHeaders(), HttpStatus.OK);
     }
@@ -533,16 +534,16 @@ public class FhirController {
                 if (param != null) { 
                 	match.setCount(((IntegerType)param.getValue()).getValue());
                     if (match.getCount() < 1 || match.getCount() > 10) {
-                        return illegalArguments(message);
+                        return illegalArguments(req, message);
                     }
                 }
             } catch (ClassCastException ex) {
-                return illegalArguments(message);
+                return illegalArguments(req, message);
             }
         } else if (PATIENT.equals(body.fhirType())) {
             match.setSearchPatient((Patient) body);
         } else {
-            return illegalArguments("Body invalid, expected Patient or Parameters");
+            return illegalArguments(req, "Body invalid, expected Patient or Parameters");
         }
         
         
@@ -552,10 +553,14 @@ public class FhirController {
         setParameters(wrapper, match.getSearchPatient());
         
         Bundle b = this.processQuery(wrapper, destinationId).getBody();
-        
+
         IDIMatch.score(b, match);
-        
-        return new ResponseEntity<>(b, HttpStatus.OK);
+
+        // Negotiate the response Content-Type from the original request (the wrapper's
+        // parameters were reset above, which would hide a _format parameter). Setting
+        // it explicitly bypasses the global SOAP-oriented content negotiation, which
+        // ignores the Accept header and defaults to XML.
+        return new ResponseEntity<>(b, ContentUtils.getHeaders(req), HttpStatus.OK);
     }
     
     /**
@@ -647,22 +652,22 @@ public class FhirController {
         }
     }
     
-    private ResponseEntity<Resource> notFound(String id) {
+    private ResponseEntity<Resource> notFound(HttpServletRequest req, String id) {
         OperationOutcome oo = new OperationOutcome();
         OperationOutcomeIssueComponent issue = oo.addIssue();
         issue.setCode(IssueType.NOTFOUND);
         issue.setSeverity(IssueSeverity.ERROR);
         issue.setDiagnostics("Resource not found " + id);
-        return new ResponseEntity<>(oo, HttpStatus.NOT_FOUND);
+        return new ResponseEntity<>(oo, ContentUtils.getHeaders(req), HttpStatus.NOT_FOUND);
     }
-    
-    private ResponseEntity<Resource> illegalArguments(String message) {
+
+    private ResponseEntity<Resource> illegalArguments(HttpServletRequest req, String message) {
         OperationOutcome oo = new OperationOutcome();
         OperationOutcomeIssueComponent issue = oo.addIssue();
         issue.setCode(IssueType.INVALID);
         issue.setSeverity(IssueSeverity.ERROR);
         issue.setDiagnostics(message);
-        return new ResponseEntity<>(oo, HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(oo, ContentUtils.getHeaders(req), HttpStatus.BAD_REQUEST);
     }
     
     /**
@@ -1183,7 +1188,7 @@ public class FhirController {
                 .addCoding(new Coding(system, code, null))
             ).setDiagnostics(uex.getCause().getMessage());
         setRetryCoding(issue, RetryStrategy.CONTACT_SUPPORT);
-        return new ResponseEntity<>(oo, HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(oo, ContentUtils.getHeaders(req), HttpStatus.INTERNAL_SERVER_ERROR);
     }
     
     private static RetryStrategy setRetryCoding(OperationOutcomeIssueComponent issue, RetryStrategy retry) {

--- a/src/test/java/gov/cdc/izgateway/xform/endpoints/fhir/FhirControllerTests.java
+++ b/src/test/java/gov/cdc/izgateway/xform/endpoints/fhir/FhirControllerTests.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -16,15 +18,31 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleType;
+import org.hl7.fhir.r4.model.DateType;
+import org.hl7.fhir.r4.model.HumanName;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Resource;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
+import gov.cdc.izgateway.configuration.AppProperties;
+import gov.cdc.izgateway.logging.RequestContext;
 import gov.cdc.izgateway.security.AccessControlRegistry;
+import gov.cdc.izgateway.security.IzgPrincipal;
+import gov.cdc.izgateway.soap.message.SubmitSingleMessageResponse;
 import gov.cdc.izgateway.xform.endpoints.hub.HubController;
+import gov.cdc.izgw.v2tofhir.utils.ContentUtils;
+import gov.cdc.izgw.v2tofhir.utils.FhirIdCodec;
 import gov.cdc.izgw.v2tofhir.utils.IzQuery;
 import gov.cdc.izgw.v2tofhir.utils.QBPUtils;
 
@@ -174,7 +192,174 @@ class FhirControllerTests {
         assertFalse(FhirController.isPatientReference("   "));
     }
 
+    // --- FHIR response content negotiation -----------------------------------------------
+    //
+    // The FHIR endpoints bypass Spring's global content negotiation (which is SOAP-oriented:
+    // it ignores Accept and defaults to XML) by setting Content-Type explicitly via
+    // ContentUtils.getHeaders(). These tests pin that behavior for the paths that build
+    // their own ResponseEntity rather than reusing processQuery's headers.
+
+    private static final String MATCH_URI = "/fhir/dev/Patient/$match";
+
+    /** A minimal RSP_K11 response as returned by an IIS for an immunization history query. */
+    private static final String RSP_MESSAGE = String.join("\r",
+        "MSH|^~\\&|TESTIIS|TESTIIS|TESTAPP|TESTORG|20240101120000||RSP^K11^RSP_K11|X234|P|2.5.1",
+        "MSA|AA|1234",
+        "QAK|Q1|OK|Z34^Request Immunization History^CDCPHINVS",
+        "QPD|Z34^Request Immunization History^CDCPHINVS|Q1|0000001^^^TEST^MR",
+        "PID|1||0000001^^^TEST^MR||CuyahogaAIRA^MarnyAIRA^^^^^L||19600507|F"
+    );
+
+    @AfterEach
+    void clearRequestContext() {
+        RequestContext.clear();
+    }
+
+    @Test
+    void matchHonorsFhirJsonAccept() throws Exception {
+        initRequestContext();
+        FhirController controller = controller(hubReturning(RSP_MESSAGE));
+        HttpServletRequest req = fhirRequest(MATCH_URI, ContentUtils.FHIR_PLUS_JSON_VALUE);
+
+        ResponseEntity<Resource> res = controller.iisPatientMatch("dev", matchParameters(), req);
+
+        assertEquals(HttpStatus.OK, res.getStatusCode());
+        assertEquals(ContentUtils.FHIR_PLUS_JSON_VALUE, res.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+        Bundle b = (Bundle) res.getBody();
+        assertNotNull(b);
+        assertEquals(BundleType.SEARCHSET, b.getType());
+        assertTrue(b.getEntry().stream().anyMatch(e -> e.getResource() instanceof Patient),
+            "match result should contain the matched Patient");
+    }
+
+    @Test
+    void matchHonorsXmlAccept() throws Exception {
+        initRequestContext();
+        FhirController controller = controller(hubReturning(RSP_MESSAGE));
+        HttpServletRequest req = fhirRequest(MATCH_URI, "application/xml");
+
+        ResponseEntity<Resource> res = controller.iisPatientMatch("dev", matchParameters(), req);
+
+        assertEquals(HttpStatus.OK, res.getStatusCode());
+        assertEquals(ContentUtils.FHIR_PLUS_XML_VALUE, res.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+    }
+
+    @Test
+    void matchDefaultsToJsonWithoutAccept() throws Exception {
+        initRequestContext();
+        FhirController controller = controller(hubReturning(RSP_MESSAGE));
+        HttpServletRequest req = fhirRequest(MATCH_URI, null);
+
+        ResponseEntity<Resource> res = controller.iisPatientMatch("dev", matchParameters(), req);
+
+        assertEquals(HttpStatus.OK, res.getStatusCode());
+        assertEquals(ContentUtils.FHIR_PLUS_JSON_VALUE, res.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+    }
+
+    @Test
+    void matchHonorsFormatParameter() throws Exception {
+        initRequestContext();
+        FhirController controller = controller(hubReturning(RSP_MESSAGE));
+        // _format must be read from the original request; the internal wrapper's
+        // parameters are reset before the query is built.
+        HttpServletRequest req = fhirRequest(MATCH_URI, null);
+        when(req.getParameter("_format")).thenReturn("xml");
+
+        ResponseEntity<Resource> res = controller.iisPatientMatch("dev", matchParameters(), req);
+
+        assertEquals(HttpStatus.OK, res.getStatusCode());
+        assertEquals(ContentUtils.FHIR_PLUS_XML_VALUE, res.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+    }
+
+    @Test
+    void matchInvalidBodyErrorHonorsAccept() throws Exception {
+        FhirController controller = controller(mock(HubController.class));
+        HttpServletRequest req = fhirRequest(MATCH_URI, ContentUtils.FHIR_PLUS_JSON_VALUE);
+
+        ResponseEntity<Resource> res = controller.iisPatientMatch("dev", new Bundle(), req);
+
+        assertEquals(HttpStatus.BAD_REQUEST, res.getStatusCode());
+        assertEquals(ContentUtils.FHIR_PLUS_JSON_VALUE, res.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+        assertTrue(res.getBody() instanceof OperationOutcome);
+    }
+
+    @Test
+    void connectionTestHonorsAccept() throws Exception {
+        FhirController controller = controller(mock(HubController.class));
+        HttpServletRequest req = fhirRequest("/fhir/dev/Patient", ContentUtils.FHIR_PLUS_JSON_VALUE);
+        when(req.getParameter("_summary")).thenReturn("count");
+
+        ResponseEntity<Bundle> res = controller.iisQuery("dev", req);
+
+        assertEquals(HttpStatus.OK, res.getStatusCode());
+        assertEquals(ContentUtils.FHIR_PLUS_JSON_VALUE, res.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+        assertNotNull(res.getBody());
+        assertEquals(100, res.getBody().getTotal());
+    }
+
+    @Test
+    void readNotFoundHonorsAccept() throws Exception {
+        FhirController controller = controller(mock(HubController.class));
+        // Decodes cleanly but has no system|value pair, so the read reports not-found
+        // before any downstream query is attempted.
+        String id = FhirIdCodec.encode("TEST");
+        HttpServletRequest req = fhirRequest("/fhir/dev/Patient/" + id, ContentUtils.FHIR_PLUS_JSON_VALUE);
+
+        ResponseEntity<Resource> res = controller.iisRead("dev", id, req);
+
+        assertEquals(HttpStatus.NOT_FOUND, res.getStatusCode());
+        assertEquals(ContentUtils.FHIR_PLUS_JSON_VALUE, res.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+        assertTrue(res.getBody() instanceof OperationOutcome);
+    }
+
     // --- helpers -------------------------------------------------------------------------
+
+    private static FhirController controller(HubController hub) {
+        return new FhirController(hub, new FhirController.FhirConfiguration(), mock(AccessControlRegistry.class));
+    }
+
+    private static HubController hubReturning(String hl7Message) throws Exception {
+        HubController hub = mock(HubController.class);
+        doReturn(new ResponseEntity<>(new SubmitSingleMessageResponse(hl7Message), HttpStatus.OK))
+            .when(hub).submitSoapRequest(any(), any());
+        return hub;
+    }
+
+    private static HttpServletRequest fhirRequest(String uri, String accept) {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getParameterMap()).thenReturn(Collections.emptyMap());
+        when(req.getRequestURI()).thenReturn(uri);
+        when(req.getHeader(HttpHeaders.ACCEPT)).thenReturn(accept);
+        return req;
+    }
+
+    private static Parameters matchParameters() {
+        Patient patient = new Patient();
+        patient.addName(new HumanName().setFamily("CuyahogaAIRA").addGiven("MarnyAIRA"));
+        patient.setBirthDateElement(new DateType("1960-05-07"));
+        Parameters params = new Parameters();
+        params.addParameter().setName("resource").setResource(patient);
+        return params;
+    }
+
+    private static void initRequestContext() {
+        if (AppProperties.getInstance() == null) {
+            // TransactionData's constructor consults the static AppProperties instance,
+            // which Spring registers at startup; the constructor self-registers it.
+            new AppProperties();
+        }
+        RequestContext.init();
+        RequestContext.getSourceInfo().setCommonName("test");
+        IzgPrincipal principal = new IzgPrincipal() {
+            @Override
+            public String getSerialNumberHex() {
+                return null;
+            }
+        };
+        principal.setName("TESTAPP");
+        principal.setOrganization("TESTORG");
+        RequestContext.setPrincipal(principal);
+    }
 
     private static RequestWithModifiableParameters emptyRequest() {
         HttpServletRequest base = mock(HttpServletRequest.class);

--- a/testing/scripts/TS_Integration_Test.postman_collection.json
+++ b/testing/scripts/TS_Integration_Test.postman_collection.json
@@ -1,10 +1,10 @@
 {
   "info": {
-    "_postman_id": "5766507e-c769-444f-bfb6-fe8be41683de",
+    "_postman_id": "bbb59221-68c6-48c0-a78d-a632cab945a2",
     "name": "TS Integration Test",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "_exporter_id": "2729094",
-    "_collection_link": "https://go.postman.co/collection/2729094-5766507e-c769-444f-bfb6-fe8be41683de?source=collection_link"
+    "_collection_link": "https://go.postman.co/collection/2729094-bbb59221-68c6-48c0-a78d-a632cab945a2?source=collection_link"
   },
   "item": [
     {
@@ -1296,6 +1296,337 @@
                     "fhir",
                     "dev",
                     "Immunization"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "TS_TC_10a FHIR Patient $match (found)",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "const jsonData = pm.response.json();",
+                      "",
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"resourceType is Bundle\", function () {",
+                      "    pm.expect(jsonData.resourceType).to.eql(\"Bundle\");",
+                      "});",
+                      "",
+                      "// Collect all Patient resource entries",
+                      "const patientEntries = (jsonData.entry || []).filter(function (e) {",
+                      "    return e.resource && e.resource.resourceType === \"Patient\";",
+                      "});",
+                      "",
+                      "pm.test(\"entry includes exactly 1 Patient resource entry\", function () {",
+                      "    pm.expect(patientEntries).to.have.lengthOf(1);",
+                      "});",
+                      "",
+                      "pm.test(\"Patient name has family = fhirPatientFamily\", function () {",
+                      "    const patient = patientEntries[0].resource;",
+                      "    const expectedFamily = pm.variables.get(\"fhirPatientFamily\");",
+                      "    const hasFamily = (patient.name || []).some(function (n) {",
+                      "        return n.family === expectedFamily;",
+                      "    });",
+                      "    pm.expect(hasFamily, \"Expected a name with family = \" + expectedFamily).to.be.true;",
+                      "});",
+                      "",
+                      "pm.test(\"Patient name given contains fhirPatientGiven\", function () {",
+                      "    const patient = patientEntries[0].resource;",
+                      "    const expectedGiven = pm.variables.get(\"fhirPatientGiven\");",
+                      "    const hasGiven = (patient.name || []).some(function (n) {",
+                      "        return Array.isArray(n.given) && n.given.indexOf(expectedGiven) !== -1;",
+                      "    });",
+                      "    pm.expect(hasGiven, \"Expected a name whose given contains \" + expectedGiven).to.be.true;",
+                      "});",
+                      "",
+                      "pm.test(\"Patient birthDate matches fhirPatientDOB\", function () {",
+                      "    const patient = patientEntries[0].resource;",
+                      "    const expectedDOB = pm.variables.get(\"fhirPatientDOB\");",
+                      "    pm.expect(patient.birthDate).to.eql(expectedDOB);",
+                      "});",
+                      "",
+                      "pm.test(\"Patient entry has search.mode = match\", function () {",
+                      "    pm.expect(patientEntries[0].search.mode).to.eql(\"match\");",
+                      "});",
+                      "",
+                      "pm.test(\"Content-Type is FHIR JSON\", function () {",
+                      "    pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/fhir+json\");",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "protocolProfileBehavior": {
+                "disabledSystemHeaders": {
+                  "content-type": true
+                }
+              },
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"resourceType\": \"Parameters\",\n    \"parameter\": [\n        {\n            \"name\": \"resource\",\n            \"resource\": {\n                \"resourceType\": \"Patient\",\n                \"name\": [\n                    {\n                        \"given\": [\n                            \"{{fhirPatientGiven}}\"\n                        ],\n                        \"family\": \"{{fhirPatientFamily}}\"\n                    }\n                ],\n                \"birthDate\": \"{{fhirPatientDOB}}\",\n                \"address\": []\n            }\n        }\n    ]\n}"
+                },
+                "url": {
+                  "raw": "{{protocol}}://{{host}}:{{port}}/fhir/dev/Patient/$match",
+                  "protocol": "{{protocol}}",
+                  "host": [
+                    "{{host}}"
+                  ],
+                  "port": "{{port}}",
+                  "path": [
+                    "fhir",
+                    "dev",
+                    "Patient",
+                    "$match"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "TS_TC_10b FHIR Patient $match (not found)",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "const jsonData = pm.response.json();",
+                      "",
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"resourceType is Bundle\", function () {",
+                      "    pm.expect(jsonData.resourceType).to.eql(\"Bundle\");",
+                      "});",
+                      "",
+                      "const entries = jsonData.entry || [];",
+                      "",
+                      "// There should be no Patient resource in the entries",
+                      "const patientEntries = entries.filter(function (e) {",
+                      "    return e.resource && e.resource.resourceType === \"Patient\";",
+                      "});",
+                      "",
+                      "pm.test(\"No Patient resource in entry\", function () {",
+                      "    pm.expect(patientEntries).to.have.lengthOf(0);",
+                      "});",
+                      "",
+                      "// There should be one or more OperationOutcome entries",
+                      "const operationOutcomeEntries = entries.filter(function (e) {",
+                      "    return e.resource && e.resource.resourceType === \"OperationOutcome\";",
+                      "});",
+                      "",
+                      "pm.test(\"entry includes 1 or more OperationOutcome entries\", function () {",
+                      "    pm.expect(operationOutcomeEntries.length).to.be.at.least(1);",
+                      "});",
+                      "",
+                      "// At least one OperationOutcome should have an issue with details.coding.code = NF (Not Found)",
+                      "pm.test(\"An OperationOutcome has issue with details.coding.code = NF\", function () {",
+                      "    const hasNF = operationOutcomeEntries.some(function (e) {",
+                      "        return (e.resource.issue || []).some(function (issue) {",
+                      "            return ((issue.details && issue.details.coding) || []).some(function (coding) {",
+                      "                return coding.code === \"NF\";",
+                      "            });",
+                      "        });",
+                      "    });",
+                      "    pm.expect(hasNF, \"Expected an OperationOutcome issue with details.coding.code = NF\").to.be.true;",
+                      "});",
+                      "",
+                      "pm.test(\"Content-Type is FHIR JSON\", function () {",
+                      "    pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/fhir+json\");",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "protocolProfileBehavior": {
+                "disabledSystemHeaders": {
+                  "content-type": true
+                }
+              },
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json",
+                    "type": "text"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"resourceType\": \"Parameters\",\n    \"parameter\": [\n        {\n            \"name\": \"resource\",\n            \"resource\": {\n                \"resourceType\": \"Patient\",\n                \"name\": [\n                    {\n                        \"given\": [\n                            \"{{fhirNoDataPatientGiven}}\"\n                        ],\n                        \"family\": \"{{fhirNoDataPatientFamily}}\"\n                    }\n                ],\n                \"birthDate\": \"{{fhirNoDataPatientDOB}}\",\n                \"address\": []\n            }\n        }\n    ]\n}"
+                },
+                "url": {
+                  "raw": "{{protocol}}://{{host}}:{{port}}/fhir/dev/Patient/$match",
+                  "protocol": "{{protocol}}",
+                  "host": [
+                    "{{host}}"
+                  ],
+                  "port": "{{port}}",
+                  "path": [
+                    "fhir",
+                    "dev",
+                    "Patient",
+                    "$match"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "TS_TC_10c FHIR Patient $match (XML Response)",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "// Response is FHIR XML, so parse it with xml2Json",
+                      "const xmlBody = pm.response.text();",
+                      "const parsed = xml2Json(xmlBody);",
+                      "",
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Root element is Bundle\", function () {",
+                      "    pm.expect(parsed).to.have.property(\"Bundle\");",
+                      "});",
+                      "",
+                      "// Helper: always return an array for elements that may appear 0, 1, or many times",
+                      "function toArray(v) {",
+                      "    if (v === undefined || v === null) return [];",
+                      "    return Array.isArray(v) ? v : [v];",
+                      "}",
+                      "",
+                      "// Helper: read the FHIR \"value\" attribute off an element (xml2Json puts attributes under $)",
+                      "function attrValue(el) {",
+                      "    if (!el) return undefined;",
+                      "    return el.$ ? el.$.value : undefined;",
+                      "}",
+                      "",
+                      "const bundle = parsed.Bundle || {};",
+                      "const entries = toArray(bundle.entry);",
+                      "",
+                      "// Collect all Patient resources across the entries",
+                      "const patients = entries",
+                      "    .map(function (e) { return e.resource && e.resource.Patient; })",
+                      "    .filter(function (p) { return !!p; });",
+                      "",
+                      "pm.test(\"entry includes exactly 1 Patient resource entry\", function () {",
+                      "    pm.expect(patients).to.have.lengthOf(1);",
+                      "});",
+                      "",
+                      "pm.test(\"Patient name has family = fhirPatientFamily\", function () {",
+                      "    const patient = patients[0];",
+                      "    const expectedFamily = pm.variables.get(\"fhirPatientFamily\");",
+                      "    const names = toArray(patient.name);",
+                      "    const hasFamily = names.some(function (n) {",
+                      "        return attrValue(n.family) === expectedFamily;",
+                      "    });",
+                      "    pm.expect(hasFamily, \"Expected a name with family = \" + expectedFamily).to.be.true;",
+                      "});",
+                      "",
+                      "pm.test(\"Patient name given contains fhirPatientGiven\", function () {",
+                      "    const patient = patients[0];",
+                      "    const expectedGiven = pm.variables.get(\"fhirPatientGiven\");",
+                      "    const names = toArray(patient.name);",
+                      "    const hasGiven = names.some(function (n) {",
+                      "        return toArray(n.given).some(function (g) {",
+                      "            return attrValue(g) === expectedGiven;",
+                      "        });",
+                      "    });",
+                      "    pm.expect(hasGiven, \"Expected a name whose given contains \" + expectedGiven).to.be.true;",
+                      "});",
+                      "",
+                      "pm.test(\"Patient birthDate matches fhirPatientDOB\", function () {",
+                      "    const patient = patients[0];",
+                      "    const expectedDOB = pm.variables.get(\"fhirPatientDOB\");",
+                      "    pm.expect(attrValue(patient.birthDate)).to.eql(expectedDOB);",
+                      "});",
+                      "",
+                      "pm.test(\"Patient entry has search.mode = match\", function () {",
+                      "    const patientEntry = entries.filter(function (e) {",
+                      "        return e.resource && e.resource.Patient;",
+                      "    })[0];",
+                      "    pm.expect(attrValue(patientEntry.search && patientEntry.search.mode)).to.eql(\"match\");",
+                      "});",
+                      "",
+                      "pm.test(\"Content-Type is FHIR XML\", function () {",
+                      "    pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/fhir+xml\");",
+                      "});"
+                    ],
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
+                  }
+                }
+              ],
+              "protocolProfileBehavior": {
+                "disabledSystemHeaders": {
+                  "content-type": true,
+                  "accept": true
+                }
+              },
+              "request": {
+                "auth": {
+                  "type": "noauth"
+                },
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/xml",
+                    "type": "text"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/xml",
+                    "type": "text"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "<Parameters xmlns='http://hl7.org/fhir'>\n  <parameter>\n    <name value='resource'/>\n    <resource>\n      <Patient>\n        <name>\n          <family value='{{fhirPatientFamily}}'/>\n          <given value='{{fhirPatientGiven}}'/>\n        </name>\n        <birthDate value='{{fhirPatientDOB}}'/>\n        <address/>\n      </Patient>\n    </resource>\n  </parameter>\n</Parameters>"
+                },
+                "url": {
+                  "raw": "{{protocol}}://{{host}}:{{port}}/fhir/dev/Patient/$match",
+                  "protocol": "{{protocol}}",
+                  "host": [
+                    "{{host}}"
+                  ],
+                  "port": "{{port}}",
+                  "path": [
+                    "fhir",
+                    "dev",
+                    "Patient",
+                    "$match"
                   ]
                 }
               },


### PR DESCRIPTION
## Summary
FHIR `POST /fhir/{dest}/Patient/$match` always returned XML, even when the client
sent `Accept: application/fhir+json`, breaking the DIBBs Query Connector (which
expects a FHIR JSON Bundle).

## Root cause
The `$match` handler (and several other FHIR paths) built their `ResponseEntity`
without a `Content-Type` header. That left serialization to Spring's **global,
SOAP-oriented** content negotiation (`ignoreAcceptHeader(true)` + XML-first
`defaultContentType`), which ignores `Accept` and forces XML.

## Fix
Set the `Content-Type` explicitly via `ContentUtils.getHeaders(req)` on the FHIR
paths that build their own `ResponseEntity`, matching what the other FHIR paths
already do — honoring the `_format` query parameter and the `Accept` header, and
defaulting to `application/fhir+json`:
- `iisPatientMatch` (`Patient/$match`)
- `connectionTest` (`/Patient?_summary=count`)
- `notFound` and `illegalArguments` OperationOutcome responses
- the `UnexpectedException` handler

The global content negotiation config and all SOAP endpoints are left untouched.

## Tests
Adds `FhirControllerTests` coverage for `Accept`/`_format` negotiation on `$match`
(mocked hub), the connection test, invalid-body errors, and not-found reads.

Added tests to Postman for $match.  Found and Not-found but also JSON versus XML. There were no previous $match tests in Postman.

## Security review
A scoped security review of this commit found **no high-confidence vulnerabilities**
(verified that `ContentUtils.getHeaders` selects from a fixed FHIR media-type
allowlist and never reflects raw `Accept`/`_format` input into the response header).

Jira: IGDD-3169
